### PR TITLE
Document cascading replication, recommend between-group replicas, and clarify per-group manifest

### DIFF
--- a/databases/attaching-multiple-databases.mdx
+++ b/databases/attaching-multiple-databases.mdx
@@ -139,17 +139,23 @@ If you can't see the source database in the import list, ensure that you've set 
 For MySQL and Postgres databases, only text backups can be restored **between different applications**. Binary backups will only allow restoring within the same application. Bear in mind that text backups only contain the default <Hint caption="logical databases">i.e. the tables & data structures rather than the "physical" database server ([full definition](#logical-databases-vs-physical-databases) </Hint> for a database group.
 </Callout>
 
+<Callout type="warning" title="Cannot import into a replica or cascading intermediate">
+Import Database is refused on any server that is currently a replica — including a cascading intermediate. The import would either be silently overwritten by ongoing replication or fail outright due to read-only restrictions. Disable replication on the target server first, then import, then re-enable replication.
+</Callout>
+
 
 ## Replicating data between database groups
 
 You can set up replication between database groups of the **same type and compatible version**. You replicate between groups in the same application, or between applications. 
 
-Replication has the following rules:
+Replication between groups follows these rules:
 
-- A replication master in one group cannot be a replica of another group
-- A group with a single server can be the replica of a master from another group
+- A primary in one group **can** also be a replica of another group. This creates a [cascading replication chain](/:product/:version?/databases/database-replication#cascading-replication) — group A's primary streams to group B's primary, which in turn streams to group B's own replicas.
+- Cycles are not allowed: a server cannot end up replicating from one of its own downstream replicas.
+- The maximum chain depth is **16 hops**.
+- Cascading is supported for **MySQL, Postgres and Redis only**. MongoDB groups can be replicated but not cascaded.
 
-Essentially, as soon as a group has internal replication (between its own master and replicas) it can no longer be a replica of another group.
+When you scale up a group whose primary is itself a replica of another group, the new server is automatically added as a downstream replica of that primary, extending the chain.
 
 To set up replication *between* database groups:
 

--- a/databases/attaching-multiple-databases.mdx
+++ b/databases/attaching-multiple-databases.mdx
@@ -44,6 +44,8 @@ To add a new database group to an existing application using the Dashboard:
 
 We will now build your new database server and alert you when it is ready.
 
+To control the **name, engine version, or other configuration** of the new group, see [Specifying database groups via manifest](#specifying-database-groups-via-manifest) below.
+
 ## Specifying database groups via manifest
 
 If you need more control over the configuration of your database groups (for example which version of a database engine to use) you can specify the database groups for an application using your Manifest file. 
@@ -113,6 +115,10 @@ To set a new default group in your Dashboard:
 3. Click the **Make Default** button at the top of the main panel 
 
 **We will not apply any changes in env vars to your application immediately.** They will only be applied when you next redeploy your stack (we recommend you do this immediately or as soon as possible).
+
+<Callout type="info" title="Make Default is the safe way to promote a replica">
+If your replica lives in its own database group, *Make Default* is the recommended way to promote it: your environment variables repoint at the new group on next deploy, the old primary stays untouched, and you can switch back at any time. This is the modern alternative to the [`cx databases promote-replica`](/:product/:version?/toolbelt/databases-promote-replica) toolbelt command — that command is one-way and destructive, and only applies to in-group replicas.
+</Callout>
 
 <PerProduct includes={["deploy"]}>
 This pattern also applies to the **service networking addresses** of your Cloud 66 components. For more details please read our [full guide on the subject](/:product/:version?/databases/database-management#service-names-for-database-groups).

--- a/databases/database-replication.mdx
+++ b/databases/database-replication.mdx
@@ -112,6 +112,10 @@ To add an in-group replica:
 
 You can securely replicate data between databases hosted by different cloud providers over your [Application Private Network](https://help.cloud66.com/docs/security/using-application-private-networks). This allows you to stream data over the public internet without exposing it to malicious actors. 
 
+<Callout type="info" title="Between-group replication only">
+Secure multi-cloud replication via APN is only available for [between-group replication](#recommended-replicate-between-database-groups). It is not available for [in-group replicas](#legacy-scale-a-server-group-to-add-an-in-group-replica) created with *+ Add Replica*, because those replicas live alongside the primary in the same group and cloud.
+</Callout>
+
 To enable replication via APN:
 
 1. Log into your Dashboard an open the app that contains (or will contain) the replica DB (i.e. the target of the replication)

--- a/databases/database-replication.mdx
+++ b/databases/database-replication.mdx
@@ -6,6 +6,8 @@ title: Configuring database replication
 
 Database replication involves configuring a master and replica database architecture, whereby the replica is an exact copy of the master at all times. This feature is supported for MySQL, Postgres, Redis and MongoDB.
 
+For MySQL, Postgres and Redis you can also build a [cascading topology](#cascading-replication) where a replica streams from another replica rather than directly from the master.
+
 Database replication can be set up for a single application, between applications, or between database groups with various benefits:
 
 ### For a single application with one DB group
@@ -105,6 +107,54 @@ To enable replication via APN:
 
 You can enable replication via APN for existing replicas by following the same steps and making sure you check the box in step 5.
 
+## Cascading replication
+
+For **MySQL, Postgres and Redis** you can build a *cascading* replication topology — also called a chain — where a replica streams from another replica rather than directly from the primary. The simplest cascading chain has three servers: A &rarr; B &rarr; C, where B is both a replica of A and the source for C.
+
+<Callout type="info" title="Cascading is not supported for MongoDB">
+MongoDB replica sets manage replication internally and cannot be cascaded through the Cloud 66 Dashboard.
+</Callout>
+
+### Why cascading?
+
+- **Reduces load on the primary.** If you have many replicas, only one of them needs to stream directly from the primary; the others can stream from an intermediate.
+- **Geographic distribution.** Place an intermediate in each region so local replicas stream from it instead of repeatedly crossing regions.
+- **Tiered read replicas.** Group reporting or analytics replicas behind a dedicated intermediate so heavy queries don't compete with the primary's workload.
+
+### How to build a chain
+
+A cascading chain is built one hop at a time. To create A &rarr; B &rarr; C:
+
+1. Enable replication from A to B (the standard *Add Replica* or *Configure Replication* flow).
+2. Wait for the A &rarr; B replication to come up healthy.
+3. Enable replication on C, choosing **B** as the source database.
+
+When you enable replication on a server whose source is itself a replica, Cloud 66 automatically configures the chain — no extra setup is required on the intermediate server.
+
+You can also turn an existing flat primary into a cascading intermediate. Open the **Configure Replication** menu on a primary that already has its own downstream replicas and pick an upstream source: the existing replicas stay attached and the primary becomes a cascading intermediate.
+
+### Choosing a source database
+
+When you configure replication on a target server, the **Source Database** picker includes any eligible replica from another group as well as primaries. Selecting an existing replica as the source extends the chain through that server.
+
+### Limits
+
+- **Maximum chain depth: 16 hops.** Cloud 66 refuses to enable replication that would create a chain longer than 16 servers.
+- **No cycles.** A server cannot become a replica of one of its own downstream replicas.
+- **PostgreSQL 12 or later is required for cascading.** Older PostgreSQL versions are blocked at validation time. MySQL and Redis have no version restriction beyond what Cloud 66 already supports.
+
+### Promoting an intermediate replica
+
+When you promote a replica that has its own downstream replicas (for example B in A &rarr; B &rarr; C), the downstream subtree is preserved: C continues replicating from B without manual intervention. B is detached from its old upstream and reconfigured as an independent primary.
+
+### Disabling replication on a cascading intermediate
+
+Disabling replication on B in an A &rarr; B &rarr; C chain detaches B from A and reconfigures B as an independent primary. C continues replicating from B unchanged. To dismantle the whole chain, disable from the leaf upward (disable C first, then B).
+
+<Callout type="warning" title="Cannot import data into a replica">
+You cannot [import a backup](/:product/:version?/databases/attaching-multiple-databases#moving-data-between-database-groups) into a server that is currently a replica or a cascading intermediate — the imported data would either be overwritten by ongoing replication or fail outright due to read-only restrictions. Disable replication on the target server first, then import, then re-enable replication.
+</Callout>
+
 ## Disable database replication
 
 To disable replication between applications: 
@@ -113,6 +163,8 @@ To disable replication between applications:
 2. Click on **Data Sources** in the left-hand nav 
 3. Click on the replica database group in the sub-nav
 4. Select *Disable replication* and confirm to commence the disabling process.
+
+If you are disabling replication on a cascading intermediate, see [Disabling replication on a cascading intermediate](#disabling-replication-on-a-cascading-intermediate) above for the resulting topology.
 
 ## Re-synchronizing replica with master
 

--- a/databases/database-replication.mdx
+++ b/databases/database-replication.mdx
@@ -61,36 +61,52 @@ In the case that an environment variable contains multiple values, such as IP ad
 
 ## Enable database replication
 
-The process of enabling database replication varies slightly for a single application compared to replication between applications.
+There are two ways to set up replication on Cloud 66, and the choice has real consequences for what you can do later.
 
 <Callout type="warning" title="Enabling replication will disrupt live databases">
 Enabling database replication will disrupt the database serving your application during the replication configuration process. The disruption time depends entirely on your database type and size, and different databases may require a restart and/or a complete backup in order to warm-up the new server. This disruption will occur every time you scale your servers. 
 </Callout>
 
-### Single application
+### Recommended: replicate between database groups
 
-To enable replication for a single application, you need to scale up to create a replica:
+Create a new [database group](/:product/:version?/databases/attaching-multiple-databases) with one server and configure it as a replica of an existing group. The two groups can live in the same application or in different applications.
 
-1. Open the application from your [Dashboard](https://app.cloud66.com/dashboard)
-2. Click on *Data Sources* in the left-hand nav 
-3. Click on the name of the database group you want to scale
-4. Click the *+ Add Replica* button
-5. Choose a size for the new server 
-6. Click Create Server
+This is the recommended approach for almost every use case, because it gives you:
 
-### Between database groups
+- **Enable and disable replication on demand** — replication is a relationship between two groups, not a structural property of one of them.
+- **Safe, reversible promotion via *Make Default*** — switching which group is the default just repoints your root environment variables (e.g. `MYSQL_ADDRESS`) at the new group. Nothing is destroyed and you can switch back at any time. See [setting a default group](/:product/:version?/databases/attaching-multiple-databases#understanding-default-database-groups).
+- **[Cascading chains](#cascading-replication)** — A &rarr; B &rarr; C topologies are built from between-group hops.
+- **Independent versions and configuration** — each group can run a different engine version (use a [manifest file](/:product/:version?/databases/attaching-multiple-databases#specifying-database-groups-via-manifest) to control name, version, and engine).
 
-Please see our [guide to database groups](/:product/:version?/databases/attaching-multiple-databases) for details on how this works.
+The full walkthrough — including the manifest snippet for naming and versioning a new group — lives in the [database groups guide](/:product/:version?/databases/attaching-multiple-databases#replicating-data-between-database-groups). The short version:
 
-### Between applications
+1. Open the application that will contain the replica from your [Dashboard](https://app.cloud66.com/dashboard).
+2. Click on **Data Sources** in the left-hand nav and add a new database group (or select an existing single-server group).
+3. Click the down arrow next to the database server and select **Configure Replication**.
+4. Choose the **source** database to replicate from and click *Ok*.
 
-To enable replication between applications, ensure that you have a secondary application deployed, and that its database server contains at least twice as much disk space as the size of your database backup. Then:
+### Legacy: scale a server group to add an in-group replica
 
-1. Open the application for the secondary application from your [Dashboard](https://app.cloud66.com/dashboard)
-2. Click on **Data Sources** in the left-hand nav 
-3. Click on the (intended) replica database group in the sub-nav
-4. Click the down arrow next to the target database server and select **Configure replication**
-5. Choose the **source** database to replicate from and click *Ok*
+When you click **+ Add Replica** on an existing database group, the new server joins that group as a replica of the group's primary. This was the only mechanism Cloud 66 offered before multiple database groups of the same type were supported, and it remains available — but it has trade-offs you should understand before choosing it.
+
+<Callout type="warning" title="In-group replicas come with hard limits">
+
+- **You cannot disable replication on an in-group replica** — replication is part of the group's structure, not a relationship you can switch off.
+- **Promoting an in-group replica is destructive and one-way.** It requires the [`cx databases promote-replica`](/:product/:version?/toolbelt/databases-promote-replica) toolbelt command, after which the existing primary **and any other replicas in the same group are no longer usable** and must be removed.
+- **You cannot make one in-group replica the "default"** — there's only one group, so the *Make Default* mechanism doesn't apply.
+
+If your goal is read scaling, an in-group replica is fine. If you're using replication for failover, migration, version upgrades, or anything you might want to reverse, prefer the between-groups approach above.
+
+</Callout>
+
+To add an in-group replica:
+
+1. Open the application from your [Dashboard](https://app.cloud66.com/dashboard).
+2. Click on **Data Sources** in the left-hand nav.
+3. Click on the name of the database group you want to scale.
+4. Click the *+ Add Replica* button.
+5. Choose a size for the new server.
+6. Click *Create Server*.
 
 ## Secure multi-cloud replication
 

--- a/databases/database-replication.mdx
+++ b/databases/database-replication.mdx
@@ -163,13 +163,15 @@ When you configure replication on a target server, the **Source Database** picke
 - **No cycles.** A server cannot become a replica of one of its own downstream replicas.
 - **PostgreSQL 12 or later is required for cascading.** Older PostgreSQL versions are blocked at validation time. MySQL and Redis have no version restriction beyond what Cloud 66 already supports.
 
-### Promoting an intermediate replica
+### Stopping an intermediate from being a replica
 
-When you promote a replica that has its own downstream replicas (for example B in A &rarr; B &rarr; C), the downstream subtree is preserved: C continues replicating from B without manual intervention. B is detached from its old upstream and reconfigured as an independent primary.
+To take an intermediate out of a chain (for example B in A &rarr; B &rarr; C), [disable replication](#disable-database-replication) on it. B is detached from its upstream A and reconfigured as an independent primary. The downstream subtree is preserved — C continues replicating from B without any manual intervention.
 
-### Disabling replication on a cascading intermediate
+To dismantle a whole chain, work from the leaf upward: disable replication on C first, then B.
 
-Disabling replication on B in an A &rarr; B &rarr; C chain detaches B from A and reconfigures B as an independent primary. C continues replicating from B unchanged. To dismantle the whole chain, disable from the leaf upward (disable C first, then B).
+<Callout type="info" title="Not the same as `cx databases promote-replica`">
+You don't need the [`cx databases promote-replica`](/:product/:version?/toolbelt/databases-promote-replica) toolbelt command to stop an intermediate from being a replica — *Disable replication* in the Dashboard is enough, and it's chain-aware. `cx promote-replica` is a separate, destructive operation intended for in-group replicas; it doesn't apply here.
+</Callout>
 
 <Callout type="warning" title="Cannot import data into a replica">
 You cannot [import a backup](/:product/:version?/databases/attaching-multiple-databases#moving-data-between-database-groups) into a server that is currently a replica or a cascading intermediate — the imported data would either be overwritten by ongoing replication or fail outright due to read-only restrictions. Disable replication on the target server first, then import, then re-enable replication.

--- a/databases/mysql.mdx
+++ b/databases/mysql.mdx
@@ -1,0 +1,48 @@
+---
+title: Add MySQL to your application
+products: ['rails', 'deploy', 'node']
+excludeVersions: ['3']
+---
+
+## Add MySQL to your application
+
+To add a MySQL group (instance) to your application:
+
+1. Open the **application** from the [Dashboard](https://app.cloud66.com/dashboard).
+2. Click on *Data Sources* in the left-hand nav 
+3. Click on *Add Source* in the sub-nav
+4. Click the green *+ Add Data Source* button and select MySQL
+5. A drawer will open from the left, with configuration options for the server.
+6. Click *Add Server* to start the process
+
+## Choosing a MySQL version
+
+Cloud 66 supports MySQL **5.7**, **8.0**, and **8.4**. You can pin the version for your application using a [manifest file](/:product/:version?/manifest/what-is-a-manifest-file):
+
+```yaml
+production:
+    mysql:
+        configuration:
+            version: "8.4"
+```
+
+If you don't specify a version, Cloud 66 uses the most recent version it supports.
+
+## Replicating data between MySQL versions
+
+When you initiate replication between two MySQL databases on Cloud 66, we set up streaming replication between the primary and replica servers. Streaming replication relies on a compatible binary log format between the two servers, which generally isn't possible between two servers running vastly different versions of MySQL.
+
+As such, we cannot establish replication between servers running different major release levels (e.g. 5.7 and 8.0). Replication between different minor release levels (e.g. 8.0.32 and 8.0.36) should work, but you should run matching versions wherever possible.
+
+## Cascading replication for MySQL
+
+Cloud 66 supports [cascading replication](/:product/:version?/databases/database-replication#cascading-replication) (A &rarr; B &rarr; C chains) for MySQL. The intermediate server is both a replica of the upstream primary and a streaming source for its own downstream replicas. See the [cascading replication guide](/:product/:version?/databases/database-replication#cascading-replication) for setup steps, limits, and the behaviour of promote and disable on a chain.
+
+Two MySQL-specific operational notes:
+
+- **File/position-based replication.** Cloud 66 uses MySQL's classic file-and-position replication for cascading chains, not GTID-based replication. If you debug a chain manually, expect `SHOW REPLICA STATUS` (or `SHOW SLAVE STATUS` on older versions) to report `Source_Log_File` and `Read_Source_Log_Pos` rather than GTID sets.
+- **Binary log retention is 10 days.** Each server in a chain retains its binary logs for 10 days by default. Under heavy write load on a deep chain, a downstream replica that falls more than 10 days behind its immediate upstream cannot be brought back into sync from binlog alone — it will need a full resync. Watch replication lag on the deepest replicas if your write volume is high.
+
+## Uninstalling MySQL
+
+To uninstall MySQL from your servers, see our [guide to uninstalling MySQL](/:product/:version?/databases/uninstall-mysql).

--- a/databases/mysql.mdx
+++ b/databases/mysql.mdx
@@ -17,7 +17,9 @@ To add a MySQL group (instance) to your application:
 
 ## Choosing a MySQL version
 
-Cloud 66 supports MySQL **5.7**, **8.0**, and **8.4**. You can pin the version for your application using a [manifest file](/:product/:version?/manifest/what-is-a-manifest-file):
+Cloud 66 supports MySQL **5.7**, **8.0**, and **8.4**. You can pin the version for your application using a [manifest file](/:product/:version?/manifest/what-is-a-manifest-file).
+
+For the database group named **`default`** (the group Cloud 66 creates when you first add MySQL to an application):
 
 ```yaml
 production:
@@ -25,6 +27,21 @@ production:
         configuration:
             version: "8.4"
 ```
+
+For any other database group, use the `groups:` block and refer to the group by name:
+
+```yaml
+production:
+    mysql:
+        groups:
+            <your-group-name>:
+                configuration:
+                    version: "8.4"
+```
+
+<Callout type="info" title="The top-level form is not a global default">
+The top-level `mysql: configuration:` form applies **only** to the group named `default` — it is not a fallback for groups that don't have an explicit configuration. Each group must be configured under its own name in the `groups:` block.
+</Callout>
 
 If you don't specify a version, Cloud 66 uses the most recent version it supports.
 

--- a/databases/postgresql.mdx
+++ b/databases/postgresql.mdx
@@ -48,6 +48,15 @@ production:
             version: 18
 ```
 
+## Cascading replication for Postgres
+
+Cloud 66 supports [cascading replication](/:product/:version?/databases/database-replication#cascading-replication) (A &rarr; B &rarr; C chains) for Postgres. The intermediate server (B) is both a replica of the upstream primary and a streaming source for its downstream replicas.
+
+<Callout type="warning" title="Postgres 12 or later required">
+Cascading replication is only supported on **Postgres 12 and above**. On older versions Cloud 66 will refuse to enable a cascading topology at validation time. The flat primary/replica setup remains supported on all Postgres versions Cloud 66 still supports.
+</Callout>
+
+Postgres has supported cascading natively since version 9.1; the version floor here reflects the configuration mechanics Cloud 66 uses (`postgresql.auto.conf` + `standby.signal`) rather than a Postgres limitation.
 
 ## Changing the Postgres data directory
 

--- a/databases/postgresql.mdx
+++ b/databases/postgresql.mdx
@@ -24,6 +24,34 @@ As such, if you delete a user from any logical Postgres database managed by Clou
 
 If you need to add custom users to a Postgres database group, follow [this guide](/:product/:version?/databases/adding-database#adding-users-to-logical-databases) on the subject. 
 
+## Specifying the Postgres version
+
+You can pin the version of Postgres to install for your application using a [manifest file](/:product/:version?/manifest/what-is-a-manifest-file).
+
+For the database group named **`default`** (the group Cloud 66 creates when you first add Postgres to an application):
+
+```yaml
+production:
+    postgresql:
+        configuration:
+            version: 18
+```
+
+For any other database group, use the `groups:` block and refer to the group by name:
+
+```yaml
+production:
+    postgresql:
+        groups:
+            <your-group-name>:
+                configuration:
+                    version: 18
+```
+
+<Callout type="info" title="The top-level form is not a global default">
+The top-level `postgresql: configuration:` form applies **only** to the group named `default` — it is not a fallback for groups that don't have an explicit configuration. Each group must be configured under its own name in the `groups:` block.
+</Callout>
+
 ## Replicating data between Postgres versions
 
 When you initiate replication between two Postgres databases on Cloud 66, we setup [streaming replication](https://wiki.postgresql.org/wiki/Streaming_Replication) between the master and replica servers. Streaming replication is based on [log shipping](https://www.postgresql.org/docs/current/warm-standby/) between servers, which generally isn't possible between two servers running vastly different versions of Postgres.
@@ -38,15 +66,6 @@ DETAIL:  The data directory was initialized by Postgres version 16, which is not
 ```
 
 In this case, you need to upgrade the data and libraries of the master server (16) with [pg_upgrade](https://www.postgresql.org/docs/current/pgupgrade.html) before starting the replication.
-
-Remember that you can set the version of Postgres to install for your application by using a [manifest file](/:product/:version?/manifest/what-is-a-manifest-file), like so:
-
-```yaml
-production:
-    postgresql:
-        configuration:
-            version: 18
-```
 
 ## Cascading replication for Postgres
 

--- a/databases/redis.mdx
+++ b/databases/redis.mdx
@@ -14,3 +14,9 @@ To add a Redis instance to your application:
 5. A drawer will open from the left, with configuration options for the server.
 6. Click *Add Server* to start the process
 
+## Redis replication
+
+Cloud 66 supports both standard primary/replica and [cascading replication](/:product/:version?/databases/database-replication#cascading-replication) (A &rarr; B &rarr; C chains) for Redis. Redis chains its replication streams natively via `REPLICAOF`, so an intermediate replica forwards its upstream's stream to its own downstream replicas without any additional configuration.
+
+For setup, limits, and the behaviour of promote/disable on a chain, see the [database replication guide](/:product/:version?/databases/database-replication#cascading-replication).
+

--- a/manifest/_mongodb.mdx
+++ b/manifest/_mongodb.mdx
@@ -24,6 +24,8 @@ The following settings are available via the Manifest file :
 
 ### Example YAML for MongoDB
 
+For the database group named `default` (the group Cloud 66 creates when you first add MongoDB to an application):
+
 ```yaml
 mongodb:
   configuration:
@@ -31,5 +33,21 @@ mongodb:
     root_disk_size: 100
     root_disk_type: ssd
 ```
+
+For any other database group, nest the configuration under the `groups:` block and refer to the group by its Dashboard name:
+
+```yaml
+mongodb:
+  groups:
+    <your-group-name>:
+      configuration:
+        version: 2.4.8
+        root_disk_size: 100
+        root_disk_type: ssd
+```
+
+<Callout type="info" title="The top-level form is not a global default">
+The top-level `mongodb: configuration:` form applies **only** to the group named `default` — it is not a fallback for groups that don't have an explicit configuration. Each group must be configured under its own name in the `groups:` block.
+</Callout>
 
 If you need help specifying multiple databases of the same type via your Manifest, please read our guide on [Database Groups](/:product/:version?/manifest/_database-groups).

--- a/manifest/_mysql.mdx
+++ b/manifest/_mysql.mdx
@@ -26,6 +26,8 @@ The following settings are available via the Manifest file :
 
 ### Example YAML for MySQL
 
+For the database group named `default` (the group Cloud 66 creates when you first add MySQL to an application):
+
 ```yaml
 mysql:
   configuration:
@@ -36,5 +38,24 @@ mysql:
     encoding: koi8u
     iam_instance_profile_name: mysql-perms
 ```
+
+For any other database group, nest the configuration under the `groups:` block and refer to the group by its Dashboard name:
+
+```yaml
+mysql:
+  groups:
+    <your-group-name>:
+      configuration:
+        version: 8.0
+        root_disk_size: 100
+        root_disk_type: ssd
+        engine: percona
+        encoding: koi8u
+        iam_instance_profile_name: mysql-perms
+```
+
+<Callout type="info" title="The top-level form is not a global default">
+The top-level `mysql: configuration:` form applies **only** to the group named `default` — it is not a fallback for groups that don't have an explicit configuration. Each group must be configured under its own name in the `groups:` block.
+</Callout>
 
 If you need help specifying multiple databases of the same type via your Manifest, please read our guide on [Database Groups](/:product/:version?/manifest/_database-groups).

--- a/manifest/_postgresql.mdx
+++ b/manifest/_postgresql.mdx
@@ -25,6 +25,8 @@ The following settings are available via the Manifest file :
 
 ### Example YAML for Postgres
 
+For the database group named `default` (the group Cloud 66 creates when you first add Postgres to an application):
+
 ```yaml
 postgresql:
   configuration:
@@ -34,6 +36,24 @@ postgresql:
     root_disk_size: 100
     root_disk_type: ssd
 ```
+
+For any other database group, nest the configuration under the `groups:` block and refer to the group by its Dashboard name:
+
+```yaml
+postgresql:
+  groups:
+    <your-group-name>:
+      configuration:
+        iam_instance_profile_name: psql-perms
+        version: 18
+        encoding: ISO_8859_8
+        root_disk_size: 100
+        root_disk_type: ssd
+```
+
+<Callout type="info" title="The top-level form is not a global default">
+The top-level `postgresql: configuration:` form applies **only** to the group named `default` — it is not a fallback for groups that don't have an explicit configuration. Each group must be configured under its own name in the `groups:` block.
+</Callout>
 
 If you need help specifying multiple databases of the same type via your Manifest, please read our guide on [Database Groups](/:product/:version?/manifest/_database-groups).
 

--- a/manifest/_redis.mdx
+++ b/manifest/_redis.mdx
@@ -23,6 +23,8 @@ The following settings are available via the Manifest file :
 
 ### Example YAML for Redis
 
+For the database group named `default` (the group Cloud 66 creates when you first add Redis to an application):
+
 ```yaml
 redis:
   configuration:
@@ -31,5 +33,22 @@ redis:
     root_disk_type: ssd
     iam_instance_profile_name: redis-perms
 ```
+
+For any other database group, nest the configuration under the `groups:` block and refer to the group by its Dashboard name:
+
+```yaml
+redis:
+  groups:
+    <your-group-name>:
+      configuration:
+        version: 8.4
+        root_disk_size: 100
+        root_disk_type: ssd
+        iam_instance_profile_name: redis-perms
+```
+
+<Callout type="info" title="The top-level form is not a global default">
+The top-level `redis: configuration:` form applies **only** to the group named `default` — it is not a fallback for groups that don't have an explicit configuration. Each group must be configured under its own name in the `groups:` block.
+</Callout>
 
 If you need help specifying multiple databases of the same type via your Manifest, please read our guide on [Database Groups](/:product/:version?/manifest/_database-groups).

--- a/toolbelt/_databases-promote-replica.mdx
+++ b/toolbelt/_databases-promote-replica.mdx
@@ -7,6 +7,10 @@ products: ['rails', 'deploy']
 
 Promotes the specified replica database server to a standalone primary. The replica will be reconfigured as the new primary. Providing the database type is optional and is only necessary for shared servers where we can't automatically determine the target database type.
 
+<Callout type="info" title="Prefer Make Default for between-group replicas">
+This command is for **in-group replicas** (created with *+ Add Replica* on an existing database group). If your replica lives in its own database group instead, use the [Make Default](/:product/:version?/databases/attaching-multiple-databases#understanding-default-database-groups) button on the Dashboard — it repoints your environment variables at the new group on next deploy, leaves the old primary untouched, and is fully reversible. See [Enable database replication](/:product/:version?/databases/database-replication#enable-database-replication) for the trade-offs between the two approaches.
+</Callout>
+
 <Callout type="warning" title="Could result in downtime">
 This action could result in application downtime, it is advisable to choose a low traffic time to perform this action, and to place your application in maintenance mode.
 </Callout>

--- a/toolbelt/_databases-promote-replica.mdx
+++ b/toolbelt/_databases-promote-replica.mdx
@@ -5,15 +5,17 @@ alias: database promote-replica
 products: ['rails', 'deploy']
 ---
 
-Promotes the specified replica database server to a standalone master. The replica will be reconfigured as the new standalone DB. Providing the database type is optional and is only necessary for shared servers where we can't automatically determine the target database type.
+Promotes the specified replica database server to a standalone primary. The replica will be reconfigured as the new primary. Providing the database type is optional and is only necessary for shared servers where we can't automatically determine the target database type.
 
 <Callout type="warning" title="Could result in downtime">
 This action could result in application downtime, it is advisable to choose a low traffic time to perform this action, and to place your application in maintenance mode.
 </Callout>
 
-The existing master and other replicas will need to be removed after this process as after this the new configuration will have only a single database. You will be able to configure replication again by scaling up new servers. 
+When you promote a flat replica (one that has no downstream replicas of its own), the existing primary and other replicas will need to be removed after the process — the new configuration will have only a single database. You can reconfigure replication afterwards by scaling up new servers.
 
-In the case of any servers not being accessible during this time, those servers will remain unchanged. It is therefore important to stop/shut down those servers in this case (or to manually stop the DB service on those servers) as having multiple masters in a cluster could cause problems throughout the cluster.
+When you promote an intermediate replica in a [cascading chain](/:product/:version?/databases/database-replication#cascading-replication) (for example B in A &rarr; B &rarr; C), the downstream subtree is preserved: B is detached from its old upstream A and reconfigured as an independent primary, and C continues replicating from B unchanged.
+
+In the case of any servers not being accessible during this time, those servers will remain unchanged. It is therefore important to stop/shut down those servers in this case (or to manually stop the DB service on those servers) as having multiple primaries in a cluster could cause problems throughout the cluster.
 
 ```shell
 $ cx databases promote-replica --stack <stack name> [--dbtype <database type>] <replica server name>

--- a/toolbelt/_databases-resync-replica.mdx
+++ b/toolbelt/_databases-resync-replica.mdx
@@ -5,9 +5,13 @@ alias: database resync-replica
 products: ['rails', 'deploy']
 ---
 
-Re-syncs the specified replica database server with its master database server. From time-to-time your replica database may go out of sync with its master. This action attempts to re-sync your specified replica server. This can happen depending on many factors (such as DB size, frequency of change, networking between servers etc).
+Re-syncs the specified replica database server with its source. From time-to-time your replica database may go out of sync with its source. This action attempts to re-sync your specified replica server. This can happen depending on many factors (such as DB size, frequency of change, networking between servers etc).
 
 The server provided must have already been configured as a replication replica via the Cloud 66 UI. Providing the database type is optional and is only necessary for shared servers where we can’t automatically determine the target database type.
+
+<Callout type="info" title="Resync target in cascading chains">
+For replicas in a [cascading chain](/:product/:version?/databases/database-replication#cascading-replication), resync runs against the **immediate upstream** — not the root primary. For example, in A &rarr; B &rarr; C, resyncing C streams a fresh snapshot from B.
+</Callout>
 
 ```shell
 $ cx databases resync-replica --stack <application name> --dbtype <database type> <replica server name>


### PR DESCRIPTION
## Summary

Three related sets of help-content updates:

1. **Document cascading replication** for MySQL, Postgres, and Redis — Cloud 66 Central shipped this in PRs cloud66/central#7637, #7640, #7641 (plus polish #7672, #7673, all merged on `master`). Until now the docs didn't mention cascading at all and several pages contained rules and guidance that contradict the shipped behaviour.
2. **Recommend between-group replication over in-group *Add Replica***. The two paths were presented as equivalent but they aren't: between-group is strictly better for almost every use case (enable/disable on demand, safe reversible promotion via *Make Default*, cascading chains, per-group versions). In-group remains documented as the legacy path with its trade-offs spelled out.
3. **Clarify per-group manifest configuration**. The top-level `<engine>: configuration:` form looked like a global default but actually targets only the group literally named `default`. Every page that shows manifest examples now shows the top-level form *and* the `groups:<name>` form side-by-side, with a callout explaining the distinction.

## What changed

### `databases/database-replication.mdx` — canonical page

- Added a new **Cascading replication** H2 section covering: why cascading, how to build a chain, the Source Database picker, limits (16-hop max, no cycles, **PostgreSQL ≥ 12 required**), promote-preserves-downstream behaviour, disable-on-intermediate behaviour, and a callout that backups can't be imported into a replica.
- Replaced the flat *Single application / Between database groups / Between applications* subsections with:
  - **Recommended: replicate between database groups** — lists the four advantages (enable/disable, Make Default, cascading, per-group versions) and links to the manifest snippet for naming + versioning a new group.
  - **Legacy: scale a server group to add an in-group replica** — explicit trade-offs in a warning callout (no disable; destructive one-way promote via `cx`; no Make Default), framed as fine for read scaling but discouraged for failover, migration, version upgrades, or anything reversible.
- Added a callout to **Secure multi-cloud replication** noting APN replication is between-group only — not available for in-group replicas, since they live in the same group/cloud as the primary.
- Merged the previous *Promoting an intermediate replica* and *Disabling replication on a cascading intermediate* sections into a single **Stopping an intermediate from being a replica** section. The previous \"promote\" framing was misleading: in this context the operator just disables replication on the intermediate (chain-aware), they don't run `cx promote-replica` (which is a separate destructive command for in-group replicas). Added an explicit callout to that effect.
- Cross-link from the overview, plus a back-reference from the existing Disable section.

### `databases/attaching-multiple-databases.mdx`

- Rewrote the **\"Replication has the following rules\"** block. The previous rules (\"a replication master in one group cannot be a replica of another group\" and \"as soon as a group has internal replication it can no longer be a replica of another group\") are now wrong — a primary can be a replica of another group, and scaling up such a group auto-cascades the new server.
- Added a warning Callout under **Moving data between database groups**: `Import Database` is now refused on replicas and cascading intermediates (a binary import would either be silently overwritten by ongoing replication or fail outright due to read-only restrictions).
- Surfaced the existing per-group manifest snippet from \"Adding a database group to an app\" via a one-liner pointer.
- Added an info Callout under *Make Default* framing it as the safe, reversible alternative to `cx databases promote-replica`.

### `toolbelt/_databases-promote-replica.mdx`

- Added a leading info callout steering between-group users to *Make Default* (reversible, env-var-only switch) instead of this destructive command.
- Corrected the misleading copy that said the existing primary and other replicas would have to be removed after promote — that's only true for flat in-group replicas. For cascading intermediates, promote preserves the downstream subtree.
- Switched to consistent **primary** terminology in the affected paragraphs.

### `toolbelt/_databases-resync-replica.mdx`

- Added a Callout clarifying that resync runs against the **immediate upstream** in cascading chains (resyncing C in A → B → C streams from B, not A).

### `databases/postgresql.mdx`

- Added a new **Specifying the Postgres version** section with the dual-snippet pattern (default-group form + named-group form + clarifying callout), extracted from the cross-version-replication section where it was previously buried.
- Added a **Cascading replication for Postgres** subsection.
- Surfaced the **Postgres 12 or later required** version floor as a warning Callout.

### `databases/redis.mdx`

- Added a **Redis replication** section linking to the canonical cascading guide and noting that Redis chains its replication streams natively via `REPLICAOF`.

### `databases/mysql.mdx` (new file)

Mirrors the structure of `postgresql.mdx`:

- **Add MySQL to your application** — six-step Dashboard flow.
- **Choosing a MySQL version** — supported versions (5.7, 8.0, 8.4) with the dual-snippet manifest pattern.
- **Replicating data between MySQL versions** — major versions don't replicate across; matching versions recommended.
- **Cascading replication for MySQL** — link to the canonical guide plus two MySQL-specific operational notes:
  - File/position-based replication (not GTID), for anyone debugging via `SHOW REPLICA STATUS`.
  - 10-day default binlog retention; deep chains under heavy write load can outrun retention if a downstream falls far enough behind.
- **Uninstalling MySQL** — pointer to the existing uninstall page.

### `manifest/_mysql.mdx`, `manifest/_postgresql.mdx`, `manifest/_redis.mdx`, `manifest/_mongodb.mdx`

Same dual-snippet pattern applied to all four per-engine manifest reference pages: each example block now shows the top-level form (group named `default`) alongside the `groups:<name>` form, with the same clarifying callout.

## Notes / out of scope

- **No master → primary terminology pass on existing flat-replication copy.** New cascading sections use *primary/replica*; the existing flat-replication paragraphs still say *master/replica*. Aligning the whole doc set is a larger, separate change (touches inbound links and screenshots).
- **`databases/3/database-replication.mdx` not updated.** That page is for the v3 product (Kubernetes-based, `products: ['deploy']`). The cascading work shipped on the v2 product only.
- **No new MongoDB content.** MongoDB replica sets manage replication internally and are explicitly not part of the cascading feature; existing MongoDB pages remain accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)