### PR TITLE
Add docs for cx operations logs and cx logs commands

### DIFF
--- a/toolbelt/_logs.mdx
+++ b/toolbelt/_logs.mdx
@@ -4,13 +4,13 @@ title: logs
 products: all
 ---
 
-Top-level alias for [`cx operations logs`](/:product/:version?/toolbelt/commands#operations-logs). Fetches log output for any async operation (deployment, SSL setup, load balancer changes, archive/restore, etc.) by its operation `uid`.
+Top-level alias for [`cx operations logs`](/:product/:version?/toolbelt/_operations-logs). Fetches log output for any async operation (deployment, SSL setup, load balancer changes, archive/restore, etc.) by its operation `uid`.
 
 ```shell
 $ cx logs <uid> [--min-severity <level>] [--include-children] [--format text|json]
 ```
 
-This command shares its flags, behaviour, and output formats with `cx operations logs`. See the [`operations logs` reference](/:product/:version?/toolbelt/commands#operations-logs) for the full option table and output description.
+This command shares its flags, behaviour, and output formats with `cx operations logs`. See the [`operations logs` reference](/:product/:version?/toolbelt/_operations-logs) for the full option table and output description.
 
 #### Examples
 

--- a/toolbelt/_logs.mdx
+++ b/toolbelt/_logs.mdx
@@ -1,0 +1,22 @@
+---
+category: toolbelt
+title: logs
+products: all
+---
+
+Top-level alias for [`cx operations logs`](/:product/:version?/toolbelt/commands#operations-logs). Fetches log output for any async operation (deployment, SSL setup, load balancer changes, archive/restore, etc.) by its operation `uid`.
+
+```shell
+$ cx logs <uid> [--min-severity <level>] [--include-children] [--format text|json]
+```
+
+This command shares its flags, behaviour, and output formats with `cx operations logs`. See the [`operations logs` reference](/:product/:version?/toolbelt/commands#operations-logs) for the full option table and output description.
+
+#### Examples
+
+```shell
+$ cx logs c4dc7c9f53d44856adba9c
+$ cx logs c4dc7c9f53d44856adba9c --include-children
+$ cx logs c4dc7c9f53d44856adba9c --include-children -m warn
+$ cx logs c4dc7c9f53d44856adba9c --format json
+```

--- a/toolbelt/_operations-logs.mdx
+++ b/toolbelt/_operations-logs.mdx
@@ -1,0 +1,44 @@
+---
+category: toolbelt
+title: operations logs
+alias: operation logs
+products: all
+---
+
+Fetches log output for any async operation (deployment, SSL setup, load balancer changes, archive/restore, etc.) by its operation `uid`. The same command is also available as the top-level alias `cx logs <uid>`.
+
+```shell
+$ cx operations logs <uid> [--min-severity <level>] [--include-children] [--format text|json]
+```
+
+#### Options
+
+| Argument | Required? | Default | Description |
+|  ---  |  ---  |  ---  |  ---  |
+| `<uid>` | yes | — | The operation uid to fetch logs for |
+| `--min-severity, -m <level>` | no | — | Minimum severity to include. Accepts a name (`trace`, `debug`, `info`, `notice`, `warn`, `error`) or an integer `0..5`. When omitted, all severities are returned. |
+| `--include-children` | no | `false` | Aggregate logs from any child operations spawned by the parent operation. When enabled, the text format adds an operation-uid column and indents nested entries by echelon. |
+| `--format <format>` | no | `text` | Output format. `text` is human-readable; `json` emits a single-line array suitable for piping into tools like `jq`. |
+
+#### Output
+
+In `text` mode each line is rendered as:
+
+```
+<RFC3339 timestamp>  [<SEVERITY>]  [<operation uid>  | ]<message>
+```
+
+The severity label is right-aligned to 6 characters (the width of `NOTICE`). When `--include-children` is enabled, each row also shows the operation uid that produced the entry — root-level entries fall back to the uid you supplied. When `--include-children` is **off**, the uid column and pipe separator are dropped entirely and no indentation is applied.
+
+In `json` mode, each entry has `severity` (lowercase name), `message`, `timestamp`, `echelon`, and — only when `--include-children` is on — `operation_uid`.
+
+#### Examples
+
+```shell
+$ cx operations logs c4dc7c9f53d44856adba9c
+$ cx operations logs c4dc7c9f53d44856adba9c --include-children
+$ cx operations logs c4dc7c9f53d44856adba9c --include-children -m warn
+$ cx operations logs c4dc7c9f53d44856adba9c --format json
+$ cx operation logs c4dc7c9f53d44856adba9c    # singular alias
+$ cx logs c4dc7c9f53d44856adba9c              # flat top-level alias
+```


### PR DESCRIPTION
## Summary

- Adds `toolbelt/_operations-logs.mdx` documenting the new `cx operations logs <uid>` command (with the singular `cx operation logs` alias) shipped in cx hotfix #125.
- Adds `toolbelt/_logs.mdx` documenting the flat top-level `cx logs <uid>` alias, cross-linking to the canonical `_operations-logs` page.
- Covers the `--min-severity`/`-m`, `--include-children`, and `--format text|json` flags, the text-mode column layout (operation-uid column and per-echelon indent under `--include-children`), and the JSON output shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)