### PR TITLE
Add SSL auto-renewal docs (cadence, force-renewal, DNS-01 troubleshooting)

### DIFF
--- a/security/ssl-auto-renewal.mdx
+++ b/security/ssl-auto-renewal.mdx
@@ -1,5 +1,6 @@
 ---
 title: SSL auto-renewal
+description: "How Cloud 66 auto-renews Let's Encrypt certificates — the Mon/Thu renewal schedule, how to force an immediate renewal, and DNS-01 / Cloudflare troubleshooting."
 products: ['rails', 'deploy']
 ---
 

--- a/security/ssl-auto-renewal.mdx
+++ b/security/ssl-auto-renewal.mdx
@@ -1,0 +1,94 @@
+---
+title: SSL auto-renewal
+products: ['rails', 'deploy']
+---
+
+## Overview
+
+Cloud 66 automatically renews Let's Encrypt certificates (both [standard and wildcard](/:product/:version?/security/ssl)) before they expire. Most of the time you don't need to do anything — but when an auto-renewal misses, knowing the schedule, the manual force-renewal trick, and the common DNS-01 failure modes lets you fix it before your cert actually lapses.
+
+This page covers:
+
+- [When auto-renewal runs](#renewal-schedule)
+- [Forcing an immediate renewal attempt](#forcing-a-renewal)
+- [DNS-01 / Cloudflare-specific failures](#dns-01--cloudflare-troubleshooting)
+
+For setup of Let's Encrypt certificates see [Adding SSL certificates](/:product/:version?/security/ssl). For HTTP-01 challenge problems see [Troubleshooting SSL certificates](/:product/:version?/security/troubleshooting-ssl).
+
+## Renewal schedule
+
+Cloud 66's renewal scheduler runs **twice a week — Mondays and Thursdays at 14:00 UTC** — and attempts to renew any certificate whose expiry is **within 30 days**.
+
+What this means in practice:
+
+- The first renewal attempt happens 30 days before expiry, on the next Monday or Thursday at 14:00 UTC.
+- If that attempt fails (e.g. transient DNS issue, upstream Let's Encrypt error), the scheduler retries on the next scheduled run.
+- With twice-weekly runs and a 30-day window, you get up to **8 attempts** before the cert actually expires — but that only helps if the underlying problem (DNS, Cloudflare proxy, account scope) is fixed in between.
+
+<Callout type="info" title="Schedule windows are UTC">
+14:00 UTC is 10:00 EDT / 07:00 PDT / 15:00 CET. If you're monitoring renewals from your dashboard, expect new audit-log entries to land in those windows.
+</Callout>
+
+## Forcing a renewal
+
+If you've fixed an upstream issue (e.g. removed a Cloudflare proxy, updated a DNS provider credential) and don't want to wait until the next Mon/Thu run, you can trigger an immediate renewal attempt:
+
+<PerProduct includes={["rails"]}>
+1. Open your application in your [Cloud 66 Dashboard](https://app.cloud66.com/)
+2. Click *Web* → *SSL Certificate* in the left-hand nav
+3. Click the existing certificate to open its configuration
+4. Make a no-op change (e.g. toggle SSL termination off and back on, or re-save the same domain list)
+5. Click *Update*
+</PerProduct>
+
+<PerProduct includes={["deploy"]}>
+1. Open your application in your [Cloud 66 Dashboard](https://app.cloud66.com/)
+2. Click *Application* → *SSL Certificate* in the left-hand nav
+3. Click the existing certificate to open its configuration
+4. Make a no-op change (e.g. toggle SSL termination off and back on, or re-save the same domain list)
+5. Click *Update*
+</PerProduct>
+
+Updating the certificate configuration kicks off a fresh renewal attempt outside the scheduled window. Watch the timeline for the outcome.
+
+<Callout type="warning" title="Let's Encrypt rate limits still apply">
+Let's Encrypt enforces [rate limits](https://letsencrypt.org/docs/rate-limits/) per registered domain. Avoid repeated force-renewals on the same domain in a short window; you can be locked out of issuance for up to a week.
+</Callout>
+
+## DNS-01 / Cloudflare troubleshooting
+
+[Wildcard certificates](/:product/:version?/security/ssl#wildcard-certificates) use the DNS-01 challenge — Let's Encrypt asks Cloud 66 to add a TXT record to your domain via the [DNS provider](/:product/:version?/security/dns-providers) you registered. The most common failures aren't with Cloud 66 or Let's Encrypt; they're at the DNS provider side.
+
+### Cloudflare proxy is enabled on the domain
+
+If the domain whose TXT record is being verified is **proxied** (the orange cloud is on in Cloudflare's DNS panel), the TXT record will still resolve from public DNS, but some Cloudflare configurations can intercept or delay propagation. For DNS-01 specifically, the proxy setting doesn't directly block TXT lookups, but a misconfigured Cloudflare account can.
+
+If renewals are failing only on Cloudflare-managed domains, check:
+
+1. The Cloudflare API token you registered with Cloud 66 has both **Zone:Read** and **DNS:Edit** permissions on the relevant zone.
+2. The token's **Zone Resources** scope includes the specific zone — a token scoped to a different zone will fail silently with a permission error.
+3. The token has not expired.
+
+### CNAME flattening
+
+Cloudflare's [CNAME flattening](https://developers.cloudflare.com/dns/cname-flattening/) on the apex of your zone can interact poorly with DNS-01 if the challenge record is placed somewhere that resolves through a flattened CNAME. The fix is to keep the `_acme-challenge.<domain>` record on a non-flattened name (this is the default for sub-domains; only the zone apex flattens).
+
+### Account / zone scope mismatch
+
+If you have multiple Cloudflare accounts (e.g. one personal, one corporate), make sure the API token you registered with Cloud 66 belongs to the account that owns the zone for the domain on the certificate. A token from another account will not find the zone and the challenge add will fail.
+
+### Verifying the TXT record manually
+
+To check whether the challenge record was actually created during the last renewal attempt, query DNS directly from your local machine:
+
+```bash
+dig +short TXT _acme-challenge.<your-domain>
+```
+
+If the record is missing during a renewal window, the failure is on the DNS provider side. If the record is present but renewal still fails, it's a propagation timing issue (Let's Encrypt queried before the record was visible) and the next scheduled run will likely succeed.
+
+## Related
+
+- [Adding SSL certificates to apps](/:product/:version?/security/ssl)
+- [Troubleshooting SSL certificates](/:product/:version?/security/troubleshooting-ssl) — HTTP-01 challenge problems
+- [DNS providers](/:product/:version?/security/dns-providers) — registering Cloudflare and other providers

--- a/security/ssl-auto-renewal.mdx
+++ b/security/ssl-auto-renewal.mdx
@@ -2,6 +2,7 @@
 title: SSL auto-renewal
 description: "How Cloud 66 auto-renews Let's Encrypt certificates — the Mon/Thu renewal schedule, how to force an immediate renewal, and DNS-01 / Cloudflare troubleshooting."
 products: ['rails', 'deploy']
+excludeVersions: ['3']
 ---
 
 ## Overview

--- a/security/ssl-auto-renewal.mdx
+++ b/security/ssl-auto-renewal.mdx
@@ -12,9 +12,9 @@ This page covers:
 
 - [When auto-renewal runs](#renewal-schedule)
 - [Forcing an immediate renewal attempt](#forcing-a-renewal)
-- [DNS-01 / Cloudflare-specific failures](#dns-01--cloudflare-troubleshooting)
+- [DNS-01 and Cloudflare-specific failures](#dns-01-and-cloudflare-troubleshooting)
 
-For setup of Let's Encrypt certificates see [Adding SSL certificates](/:product/:version?/security/ssl). For HTTP-01 challenge problems see [Troubleshooting SSL certificates](/:product/:version?/security/troubleshooting-ssl).
+Standard (non-wildcard) certificates validate over the **HTTP-01** challenge; wildcard certificates use **DNS-01**, which is what this page's troubleshooting section covers. For certificate setup see [Adding SSL certificates](/:product/:version?/security/ssl); for HTTP-01 problems see [Troubleshooting SSL certificates](/:product/:version?/security/troubleshooting-ssl).
 
 ## Renewal schedule
 
@@ -24,10 +24,10 @@ What this means in practice:
 
 - The first renewal attempt happens 30 days before expiry, on the next Monday or Thursday at 14:00 UTC.
 - If that attempt fails (e.g. transient DNS issue, upstream Let's Encrypt error), the scheduler retries on the next scheduled run.
-- With twice-weekly runs and a 30-day window, you get up to **8 attempts** before the cert actually expires — but that only helps if the underlying problem (DNS, Cloudflare proxy, account scope) is fixed in between.
+- With twice-weekly runs over a 30-day window, that's up to roughly 8 scheduled attempts before the cert actually expires — but that only helps if the underlying problem (DNS, Cloudflare proxy, account scope) is fixed in between.
 
 <Callout type="info" title="Schedule windows are UTC">
-14:00 UTC is 10:00 EDT / 07:00 PDT / 15:00 CET. If you're monitoring renewals from your dashboard, expect new audit-log entries to land in those windows.
+The 14:00 schedule is UTC year-round (it doesn't shift with daylight saving). If you're monitoring renewals from your dashboard, expect renewal activity in the timeline during those windows.
 </Callout>
 
 ## Forcing a renewal
@@ -56,15 +56,13 @@ Updating the certificate configuration kicks off a fresh renewal attempt outside
 Let's Encrypt enforces [rate limits](https://letsencrypt.org/docs/rate-limits/) per registered domain. Avoid repeated force-renewals on the same domain in a short window; you can be locked out of issuance for up to a week.
 </Callout>
 
-## DNS-01 / Cloudflare troubleshooting
+## DNS-01 and Cloudflare troubleshooting
 
 [Wildcard certificates](/:product/:version?/security/ssl#wildcard-certificates) use the DNS-01 challenge — Let's Encrypt asks Cloud 66 to add a TXT record to your domain via the [DNS provider](/:product/:version?/security/dns-providers) you registered. The most common failures aren't with Cloud 66 or Let's Encrypt; they're at the DNS provider side.
 
-### Cloudflare proxy is enabled on the domain
+### Cloudflare API token permissions and scope
 
-If the domain whose TXT record is being verified is **proxied** (the orange cloud is on in Cloudflare's DNS panel), the TXT record will still resolve from public DNS, but some Cloudflare configurations can intercept or delay propagation. For DNS-01 specifically, the proxy setting doesn't directly block TXT lookups, but a misconfigured Cloudflare account can.
-
-If renewals are failing only on Cloudflare-managed domains, check:
+On DNS-01, failures on Cloudflare-managed domains are almost always the API token rather than the orange-cloud proxy — a proxied record still resolves from public DNS, and the proxy doesn't block the TXT lookups Let's Encrypt makes. So if renewals are failing only on Cloudflare-managed domains, check the API token you registered with Cloud 66 first:
 
 1. The Cloudflare API token you registered with Cloud 66 has both **Zone:Read** and **DNS:Edit** permissions on the relevant zone.
 2. The token's **Zone Resources** scope includes the specific zone — a token scoped to a different zone will fail silently with a permission error.

--- a/security/ssl-auto-renewal.mdx
+++ b/security/ssl-auto-renewal.mdx
@@ -14,7 +14,7 @@ This page covers:
 - [Forcing an immediate renewal attempt](#forcing-a-renewal)
 - [DNS-01 and Cloudflare-specific failures](#dns-01-and-cloudflare-troubleshooting)
 
-Standard (non-wildcard) certificates validate over the **HTTP-01** challenge; wildcard certificates use **DNS-01**, which is what this page's troubleshooting section covers. For certificate setup see [Adding SSL certificates](/:product/:version?/security/ssl); for HTTP-01 problems see [Troubleshooting SSL certificates](/:product/:version?/security/troubleshooting-ssl).
+Standard (non-wildcard) certificates validate over the **HTTP-01** challenge; wildcard certificates use **DNS-01**, which is what this page's troubleshooting section covers. For certificate setup see [Adding SSL certificates](/:product/:version?/security/ssl); for HTTP-01 problems see [Troubleshooting SSL certificates](/:product/:version?/security/troubleshooting-ssl). If your standard certificate sits behind a Cloudflare proxy, see [Configuring Let's Encrypt with Cloudflare](/:product/:version?/security/ssl#configuring-lets-encrypt-with-cloudflare) — the orange-cloud proxy affects HTTP-01, not the DNS-01 flow below.
 
 ## Renewal schedule
 
@@ -84,7 +84,7 @@ To check whether the challenge record was actually created during the last renew
 dig +short TXT _acme-challenge.<your-domain>
 ```
 
-If the record is missing during a renewal window, the failure is on the DNS provider side. If the record is present but renewal still fails, it's a propagation timing issue (Let's Encrypt queried before the record was visible) and the next scheduled run will likely succeed.
+If the record is missing during a renewal window, check the application timeline first to confirm Cloud 66 actually attempted the DNS write — a missing record can mean the write was never made (e.g. an invalid API token) as well as the provider dropping it. Once you've confirmed a write was attempted, the failure is on the DNS provider or credential side. If the record is present but renewal still fails, it's a propagation timing issue (Let's Encrypt queried before the record was visible) and the next scheduled run will likely succeed.
 
 ## Related
 

--- a/security/ssl.mdx
+++ b/security/ssl.mdx
@@ -50,7 +50,7 @@ Cloud 66 will now attempt to add a standard certificate based on your configurat
 **Cloudflare** users need to [add a Page Rule](/:product/:version?/security/troubleshooting-ssl#configuring-let-s-encrypt-with-cloudflare) to their Cloudflare configuration in order for the process described above to work.  If you run into any other problems, consult our [troubleshooting doc](/:product/:version?/security/troubleshooting-ssl).
 
 <Callout type="warning" title="Certificates require updates every 3 months">
-Let's Encrypt needs to be updated every 3 months, so you should keep this configuration in place to allow for automatic renewal. 
+Let's Encrypt needs to be updated every 3 months, so you should keep this configuration in place to allow for automatic renewal. For details on when auto-renewal runs and how to force a renewal manually, see [SSL auto-renewal](/:product/:version?/security/ssl-auto-renewal).
 </Callout>
 
 #### How standard certificates work
@@ -184,7 +184,7 @@ To set up your application:
 The challenge should now succeed. If it does not, read the rest of this guide. 
 
 <Callout type="warning" title="Let's Encrypt certs require updates every 3 months">
-Let's Encrypt needs to be updated every 3 months, so you should keep all configurations in place to allow for automatic renewal. 
+Let's Encrypt needs to be updated every 3 months, so you should keep all configurations in place to allow for automatic renewal. See [SSL auto-renewal](/:product/:version?/security/ssl-auto-renewal) for the renewal schedule and force-renewal procedure.
 </Callout>
 
 

--- a/security/ssl.mdx
+++ b/security/ssl.mdx
@@ -50,7 +50,7 @@ Cloud 66 will now attempt to add a standard certificate based on your configurat
 **Cloudflare** users need to [add a Page Rule](/:product/:version?/security/troubleshooting-ssl#configuring-let-s-encrypt-with-cloudflare) to their Cloudflare configuration in order for the process described above to work.  If you run into any other problems, consult our [troubleshooting doc](/:product/:version?/security/troubleshooting-ssl).
 
 <Callout type="warning" title="Certificates require updates every 3 months">
-Let's Encrypt needs to be updated every 3 months, so you should keep this configuration in place to allow for automatic renewal. For details on when auto-renewal runs and how to force a renewal manually, see [SSL auto-renewal](/:product/:version?/security/ssl-auto-renewal).
+Let's Encrypt needs to be updated every 3 months, so you should keep this configuration in place to allow for automatic renewal. 
 </Callout>
 
 #### How standard certificates work
@@ -184,7 +184,7 @@ To set up your application:
 The challenge should now succeed. If it does not, read the rest of this guide. 
 
 <Callout type="warning" title="Let's Encrypt certs require updates every 3 months">
-Let's Encrypt needs to be updated every 3 months, so you should keep all configurations in place to allow for automatic renewal. See [SSL auto-renewal](/:product/:version?/security/ssl-auto-renewal) for the renewal schedule and force-renewal procedure.
+Let's Encrypt needs to be updated every 3 months, so you should keep all configurations in place to allow for automatic renewal. 
 </Callout>
 
 


### PR DESCRIPTION
## Summary

Adds `security/ssl-auto-renewal.mdx` covering Cloud 66's Let's Encrypt auto-renewal:

- **Renewal schedule** — the scheduler runs Mon/Thu at 14:00 UTC and attempts renewal within 30 days of expiry.
- **Forcing a renewal** — the dashboard "update the certificate config" trick to trigger an immediate attempt, with a Let's Encrypt rate-limit caveat.
- **DNS-01 / Cloudflare troubleshooting** — API-token scope, proxy, and CNAME-flattening failure modes and how to verify the `_acme-challenge` TXT record manually.

**Scoped to Deploy v2** (`excludeVersions: ['3']`, plus `rails`).

## Why

A customer's certificate lapsed and their site started returning 526, with no docs explaining when auto-renewal runs or how to intervene. This ships the three highest-impact items (cadence, force-renewal, DNS-01 troubleshooting).

## Scope (v2 vs v3)

This page describes the **platform-side renewal scheduler** model (Cloud 66's control plane renews Let's Encrypt certs on a schedule), which applies to **Deploy v2 / Maestro** and **rails** apps. **CSv3 / Deploy v3 does not use it** — v3 manages SSL via in-cluster **cert-manager** (the cluster issues and auto-renews certificates itself). So the page is `excludeVersions: ['3']`. A CSv3 cert-manager SSL doc is a separate gap (no v3 SSL doc exists yet).

The earlier draft also added two cross-links into `security/ssl.mdx`; those have been **reverted**, because `ssl.mdx` renders on all versions (including v3) and must not link to a v3-excluded page.

## Verification

- Cadence + window confirmed against current platform behaviour: renewal runs Mon/Thu 14:00 UTC, targets certs expiring within 30 days (and not already expired).
- Confirmed against the platform source that CSv3 issues and renews certificates via in-cluster cert-manager — a different mechanism from the v2 scheduler.
- `excludeVersions: ['3']` matches the repo's page-level version-scoping convention.

## Note

This content repo has no `package.json`; `yarn validate:mdx` runs in the consuming site repo. MDX/frontmatter and intra-page anchors sanity-checked manually.
