### PR TITLE
Add guidance: when to add a dedicated worker (small Maestro K8s)

### DIFF
--- a/build-and-config/configuring-for-high-availability.mdx
+++ b/build-and-config/configuring-for-high-availability.mdx
@@ -13,16 +13,16 @@ Applications running Kubernetes v1.12 or lower do not support the multi-master f
 
 ## Choosing between a shared master and dedicated workers
 
-A new Maestro Kubernetes cluster starts with a single master node that also runs your application workloads — a "shared master" topology. This is fine for development and small production loads, but it has a hard ceiling: the same node is responsible for both Kubernetes control-plane traffic (the API server, scheduler, controller manager, etcd) and your app's containers, and those two responsibilities compete for the same CPU, memory, and disk I/O.
+By default, a new Maestro Kubernetes cluster starts with a single **shared master** — one master node that also runs your application workloads. This is fine for development and small production loads, but it has a hard ceiling: the same node is responsible for both Kubernetes control-plane traffic (the API server, scheduler, controller manager, etcd) and your app's containers, and those two responsibilities compete for the same CPU, memory, and disk I/O.
 
-The right time to add a **dedicated worker** — a node that runs *only* application pods, with the master returned to control-plane duties — is when you start seeing any of:
+The right time to add a **dedicated worker** — a node that runs *only* application pods, giving your app's containers a home away from the master — is when you start seeing any of:
 
 - **Slow `kubectl` responses or Dashboard timeline lag** when nothing else is changing. The API server is being starved by application containers.
 - **Scheduling decisions that take noticeably longer than they used to** (new pods sitting in `Pending` for tens of seconds before being placed).
 - **Pod evictions on the master node** — the kubelet evicting application pods because the node itself is under memory or disk pressure. These show up on the cluster's events feed and in the timeline.
 - **etcd warnings in the master's logs** about slow writes (`took too long`, `apply request took too long`). etcd is the most latency-sensitive part of the control plane.
 
-If you're hitting any of those on a single-master cluster, add one dedicated worker before chasing other tuning options — it's usually the fastest path back to a healthy cluster. The procedure is the same as [adding any node](#adding-nodes-to-an-application); pick *Worker* in step 5.
+If you're hitting any of those on a single-master cluster, adding one dedicated worker is usually the fastest fix — it gives your application pods a node of their own. The exception is etcd slow-write warnings: if those persist after adding a worker, the master node itself may be undersized (CPU or disk), which a worker won't address. The procedure is the same as [adding any node](#adding-nodes-to-an-application); pick *Worker* in step 5.
 
 <Callout type="info" title="One worker first, then think about HA">
 Adding the first dedicated worker is a different decision from going to a full HA topology (three masters + workers). A single-master + single-worker cluster is not HA — losing the master still takes the cluster down — but it does take the workload pressure off the master and is often enough for small production apps. Move to three masters when you also need the cluster to survive a master node failure.

--- a/build-and-config/configuring-for-high-availability.mdx
+++ b/build-and-config/configuring-for-high-availability.mdx
@@ -1,6 +1,7 @@
 ---
 title:  "Configuring container clusters for high availability"
 products: ['deploy']
+excludeVersions: ['3']
 ---
 
 ## Overview

--- a/build-and-config/configuring-for-high-availability.mdx
+++ b/build-and-config/configuring-for-high-availability.mdx
@@ -11,6 +11,23 @@ In order to achieve high availability for your application, you need multiple re
 Applications running Kubernetes v1.12 or lower do not support the multi-master feature on Cloud 66. If you have deployed an application via Cloud 66 before March 2019, you will need to **redeploy your application "with upgrades" and choose to perform a Kubernetes upgrade** (note that this will incur significant downtime as your cluster will be recreated). All applications deployed after **March 2019** on version v1.13 and above automatically support multi-master clusters.
 </Callout>
 
+## Choosing between a shared master and dedicated workers
+
+A new Maestro Kubernetes cluster starts with a single master node that also runs your application workloads — a "shared master" topology. This is fine for development and small production loads, but it has a hard ceiling: the same node is responsible for both Kubernetes control-plane traffic (the API server, scheduler, controller manager, etcd) and your app's containers, and those two responsibilities compete for the same CPU, memory, and disk I/O.
+
+The right time to add a **dedicated worker** — a node that runs *only* application pods, with the master returned to control-plane duties — is when you start seeing any of:
+
+- **Slow `kubectl` responses or Dashboard timeline lag** when nothing else is changing. The API server is being starved by application containers.
+- **Scheduling decisions that take noticeably longer than they used to** (new pods sitting in `Pending` for tens of seconds before being placed).
+- **Pod evictions on the master node** — the kubelet evicting application pods because the node itself is under memory or disk pressure. These show up on the cluster's events feed and in the timeline.
+- **etcd warnings in the master's logs** about slow writes (`took too long`, `apply request took too long`). etcd is the most latency-sensitive part of the control plane.
+
+If you're hitting any of those on a single-master cluster, add one dedicated worker before chasing other tuning options — it's usually the fastest path back to a healthy cluster. The procedure is the same as [adding any node](#adding-nodes-to-an-application); pick *Worker* in step 5.
+
+<Callout type="info" title="One worker first, then think about HA">
+Adding the first dedicated worker is a different decision from going to a full HA topology (three masters + workers). A single-master + single-worker cluster is not HA — losing the master still takes the cluster down — but it does take the workload pressure off the master and is often enough for small production apps. Move to three masters when you also need the cluster to survive a master node failure.
+</Callout>
+
 ## Adding nodes to an application
 
 To add nodes to an existing application:

--- a/build-and-config/configuring-for-high-availability.mdx
+++ b/build-and-config/configuring-for-high-availability.mdx
@@ -13,16 +13,16 @@ Applications running Kubernetes v1.12 or lower do not support the multi-master f
 
 ## Choosing between a shared master and dedicated workers
 
-By default, a new Maestro Kubernetes cluster starts with a single **shared master** — one master node that also runs your application workloads. This is fine for development and small production loads, but it has a hard ceiling: the same node is responsible for both Kubernetes control-plane traffic (the API server, scheduler, controller manager, etcd) and your app's containers, and those two responsibilities compete for the same CPU, memory, and disk I/O.
+By default, a new Maestro Kubernetes cluster starts with a single **shared master** — one master node that also runs your application workloads. This is fine for development and small production loads, but it has a hard ceiling: the same node is responsible for both Kubernetes control-plane traffic (the API server, scheduler, controller manager, etcd) and your app's containers, and those two responsibilities compete for the same CPU, memory, and disk I/O (the last mostly mattering to etcd).
 
 The right time to add a **dedicated worker** — a node that runs *only* application pods, giving your app's containers a home away from the master — is when you start seeing any of:
 
-- **Slow `kubectl` responses or Dashboard timeline lag** when nothing else is changing. The API server is being starved by application containers.
+- **Slow `kubectl` responses or Dashboard timeline lag** when nothing else is changing. The API server may be starved by application containers competing for the node's resources.
 - **Scheduling decisions that take noticeably longer than they used to** (new pods sitting in `Pending` for tens of seconds before being placed).
 - **Pod evictions on the master node** — the kubelet evicting application pods because the node itself is under memory or disk pressure. These show up on the cluster's events feed and in the timeline.
 - **etcd warnings in the master's logs** about slow writes (`took too long`, `apply request took too long`). etcd is the most latency-sensitive part of the control plane.
 
-If you're hitting any of those on a single-master cluster, adding one dedicated worker is usually the fastest fix — it gives your application pods a node of their own. The exception is etcd slow-write warnings: if those persist after adding a worker, the master node itself may be undersized (CPU or disk), which a worker won't address. The procedure is the same as [adding any node](#adding-nodes-to-an-application); pick *Worker* in step 5.
+If you're hitting any of those on a single-master cluster, adding one dedicated worker is usually the fastest fix — it gives your application pods a node of their own. The exception is etcd slow-write warnings: if those persist after adding a worker, the master node itself may be undersized (CPU or disk), which a worker won't address. The procedure is the same as [adding any node](#adding-nodes-to-an-application); pick *Worker* when prompted to choose the node role.
 
 <Callout type="info" title="One worker first, then think about HA">
 Adding the first dedicated worker is a different decision from going to a full HA topology (three masters + workers). A single-master + single-worker cluster is not HA — losing the master still takes the cluster down — but it does take the workload pressure off the master and is often enough for small production apps. Move to three masters when you also need the cluster to survive a master node failure.


### PR DESCRIPTION
## Summary

- Adds a "Choosing between a shared master and dedicated workers" section to `build-and-config/configuring-for-high-availability.mdx` (when to add a dedicated worker on a small single-master cluster).
- **Scopes the whole page to Deploy v2** (`excludeVersions: ['3']`). This page is entirely Maestro/v2 (master/worker/shared, three-master HA, server-level scaling) and was previously rendering for v3 too. CSv3/v3 uses a different model — Reduced vs High Availability cluster types — covered separately in `build-and-config/3/cluster-operations.mdx` (PR #17).

## Why

A small-cluster customer hit this twice on the same stack three weeks apart. The HA doc covered multi-master scaling but said nothing about the single-master → dedicated-worker transition point, which is a recurring question for small-cluster operators.

## Scope (v2 vs v3)

The content is Maestro/CSv2 (master/worker/shared topology, three-master consensus). CSv3 has no "masters to add" — it has **Reduced Availability** (shared managers) and **High Availability** (3+ dedicated managers + workers) cluster types with an "Upgrade to High Availability" flow. So this page is now `excludeVersions: ['3']`, and the CSv3 equivalent ("Reduced vs High Availability — when to upgrade") is added to the CSv3 cluster-operations page in PR #17.

## Verification

- "Pick *Worker*" matches the existing add-node flow (step 5: *"Choose whether the new node(s) will be Master(s) or a Worker(s)"*).
- The intra-page anchor `#adding-nodes-to-an-application` resolves.
- `excludeVersions: ['3']` is the repo's established page-level version-scoping mechanism (e.g. `databases/postgresql.mdx`, `databases/redis.mdx`).

## Note

This content repo has no `package.json`; `yarn validate:mdx` runs in the consuming site repo. MDX and the intra-page anchor sanity-checked manually.
