### PR TITLE
Clarify CSv3 backup format is system-determined (not selectable)

### DIFF
--- a/databases/3/database-backups.mdx
+++ b/databases/3/database-backups.mdx
@@ -21,6 +21,12 @@ To add backups to a database:
 
 If your database has replication enabled, you can choose to take the backup from the primary or replica of the database.
 
+## Backup format
+
+Unlike on CSv2/Maestro, **backup format is not customer-configurable in CSv3**. The format is determined by the backup system that your database engine uses — for example, CNPG-managed Postgres clusters use Barman, which produces its own backup file layout. There is no equivalent of the `--backup-type binary|text` flag from the CSv2 toolbelt; Cloud 66 picks the format that the underlying system supports natively, and restore is always handled through the Dashboard or the v3 toolbelt rather than by reading the raw backup files.
+
+If you need a portable, engine-readable dump (for example, to migrate to a third-party Postgres host), use your database engine's standard export tooling (`pg_dump`, `mysqldump`, etc.) against the live database rather than relying on the managed backup files.
+
 ## Restoring database backups
 
 Restoring backups involves creating a new database from the backup. Here are the steps:


### PR DESCRIPTION
## Summary

Adds a short "Backup format" section to `databases/3/database-backups.mdx` explaining that, unlike CSv2/Maestro, CSv3 has **no customer-selectable binary/text format toggle** — the format is fixed by the backup system the database engine uses (e.g. Barman for CNPG-managed Postgres). Points users who need a portable dump at standard engine export tooling (`pg_dump`, `mysqldump`).

## Why

On HS #33560 a customer (Latitude) went looking for the binary/text format option that exists on CSv2 and was confused by its absence on CSv3. The originating ticket (SUP-1012) assumed the toggle existed but was undocumented; in fact it doesn't exist on CSv3 at all. The ticket was **closed as Invalid** (premise incorrect), but the underlying customer confusion is real and this small clarification addresses it.

## Linear

- SUP-1012 (closed Invalid — this doc clarification stands on its own)
- Originating ticket: HS #33560

## Test plan

- [ ] `yarn validate:mdx` passes
- [ ] Section renders between the managed-backups and restore sections
- [ ] Confirm "Barman for CNPG-managed Postgres" is accurate for current CSv3 engines before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)