### PR TITLE
Document all DNS providers (Hetzner, Azure, TransIP)

### DIFF
--- a/partials/_azure_dns.mdx
+++ b/partials/_azure_dns.mdx
@@ -1,0 +1,8 @@
+Azure DNS requires a **service principal** (a Microsoft Entra ID, formerly Azure AD, app registration) with permission to manage your DNS zone. Cloud 66 needs five values: your subscription ID, tenant ID, client ID, client secret, and resource group.
+
+1. In the [Azure portal](https://portal.azure.com/), go to **Microsoft Entra ID → App registrations** and register a new application. This creates a service principal.
+2. Open the application's **Certificates & secrets** and create a new **client secret**, then copy its value (it is shown only once).
+3. On the resource group that contains your DNS zone, open **Access control (IAM)** and assign your service principal the **DNS Zone Contributor** role.
+4. Collect your **Subscription ID**, **Directory (tenant) ID**, **Application (client) ID**, the **client secret** value, and the **resource group** name.
+
+You can now add Azure DNS to your Cloud 66 account using these credentials ([see above](#set-up-a-dns-provider)).

--- a/partials/_dns_provider_tabs.mdx
+++ b/partials/_dns_provider_tabs.mdx
@@ -1,4 +1,5 @@
 import Route53DnsPartial from './_route53_dns.mdx';
+import AzureDnsPartial from './_azure_dns.mdx';
 import CloudflareDnsPartial from './_cloudflare_dns.mdx';
 import DigitaloceanDnsPartial from './_digitalocean_dns.mdx';
 import DnsimpleDnsPartial from './_dnsimple_dns.mdx';
@@ -12,11 +13,16 @@ import Ns1DnsPartial from './_ns1_dns.mdx';
 import OvhDnsPartial from './_ovh_dns.mdx';
 import Rfc2136DnsPartial from './_rfc2136_dns.mdx';
 import SakuracloudDnsPartial from './_sakuracloud_dns.mdx';
+import TransipDnsPartial from './_transip_dns.mdx';
 
-<FilteredContentBox labels={["Amazon Route53", "Cloudflare DNS", "DigitalOcean", "DNSimple", "DnsMadeEasy", "Gehirn", "Google Cloud DNS", "Hetzner DNS", "Linode DNS", "LuaDNS", "NS1", "OVH DNS", "RFC 2136", "SakuraCloud"]}>
+<FilteredContentBox labels={["Amazon Route53", "Azure DNS", "Cloudflare DNS", "DigitalOcean", "DNSimple", "DnsMadeEasy", "Gehirn", "Google Cloud DNS", "Hetzner DNS", "Linode DNS", "LuaDNS", "NS1", "OVH DNS", "RFC 2136", "SakuraCloud", "TransIP"]}>
 
 <FilteredContent filter="Amazon Route53">
 <PartialWrapper partial={Route53DnsPartial} />
+</FilteredContent>
+
+<FilteredContent filter="Azure DNS">
+<PartialWrapper partial={AzureDnsPartial} />
 </FilteredContent>
 
 <FilteredContent filter="Cloudflare DNS">
@@ -69,6 +75,10 @@ import SakuracloudDnsPartial from './_sakuracloud_dns.mdx';
 
 <FilteredContent filter="SakuraCloud">
 <PartialWrapper partial={SakuracloudDnsPartial} />
+</FilteredContent>
+
+<FilteredContent filter="TransIP">
+<PartialWrapper partial={TransipDnsPartial} />
 </FilteredContent>
 
 </FilteredContentBox>

--- a/partials/_dns_provider_tabs.mdx
+++ b/partials/_dns_provider_tabs.mdx
@@ -5,6 +5,7 @@ import DnsimpleDnsPartial from './_dnsimple_dns.mdx';
 import DnsmadeeasyDnsPartial from './_dnsmadeeasy_dns.mdx';
 import GehirnDnsPartial from './_gehirn_dns.mdx';
 import GoogleDnsPartial from './_google_dns.mdx';
+import HetznerDnsPartial from './_hetzner_dns.mdx';
 import LinodeDnsPartial from './_linode_dns.mdx';
 import LuadnsDnsPartial from './_luadns_dns.mdx';
 import Ns1DnsPartial from './_ns1_dns.mdx';
@@ -12,7 +13,7 @@ import OvhDnsPartial from './_ovh_dns.mdx';
 import Rfc2136DnsPartial from './_rfc2136_dns.mdx';
 import SakuracloudDnsPartial from './_sakuracloud_dns.mdx';
 
-<FilteredContentBox labels={["Amazon Route53", "Cloudflare DNS", "DigitalOcean", "DNSimple", "DnsMadeEasy", "Gehirn", "Google Cloud DNS", "Linode DNS", "LuaDNS", "NS1", "OVH DNS", "RFC 2136", "SakuraCloud"]}>
+<FilteredContentBox labels={["Amazon Route53", "Cloudflare DNS", "DigitalOcean", "DNSimple", "DnsMadeEasy", "Gehirn", "Google Cloud DNS", "Hetzner DNS", "Linode DNS", "LuaDNS", "NS1", "OVH DNS", "RFC 2136", "SakuraCloud"]}>
 
 <FilteredContent filter="Amazon Route53">
 <PartialWrapper partial={Route53DnsPartial} />
@@ -40,6 +41,10 @@ import SakuracloudDnsPartial from './_sakuracloud_dns.mdx';
 
 <FilteredContent filter="Google Cloud DNS">
 <PartialWrapper partial={GoogleDnsPartial} />
+</FilteredContent>
+
+<FilteredContent filter="Hetzner DNS">
+<PartialWrapper partial={HetznerDnsPartial} />
 </FilteredContent>
 
 <FilteredContent filter="Linode DNS">

--- a/partials/_hetzner_dns.mdx
+++ b/partials/_hetzner_dns.mdx
@@ -1,0 +1,9 @@
+Hetzner requires an **API token** in order to grant access to DNS management. Generate the token in the Hetzner Console, not the older DNS Console at `dns.hetzner.com`, which is being retired.
+
+1. Log into your [Hetzner Console](https://console.hetzner.cloud/)
+2. Open your project and select **Security** from the left menu
+3. Click **API tokens** in the top menu bar
+4. Click **Generate API token**, enter a description, and select **Read & Write** permissions
+5. Copy the token and store it somewhere safe. Hetzner only displays the token once.
+
+You can now add Hetzner to your Cloud 66 account using this token ([see above](#set-up-a-dns-provider)).

--- a/partials/_transip_dns.mdx
+++ b/partials/_transip_dns.mdx
@@ -1,10 +1,10 @@
-TransIP requires your account **username**, an **API key**, and a **global key** setting. The API key is the private key from a TransIP *key pair*, which you create in the control panel.
+TransIP requires your account **username**, an **API key**, and a **global key** setting. The API key is the private key from a TransIP *key pair*, which you create in the control panel and upload to Cloud 66 as a file.
 
 1. Log into the [TransIP control panel](https://www.transip.eu/cp/) and go to **My account → API**
 2. Add a new **key pair** and give it a label (for example, `cloud66`)
-3. Choose how the key may be used:
-   - Allow it to be used from non-whitelisted IP addresses, and set **global key** to `yes` when you add it to Cloud 66, or
-   - Keep it restricted to whitelisted IPs, in which case you must whitelist the addresses Cloud 66 connects from (contact Cloud 66 support for these) and leave **global key** unset
-4. Copy the **private key** that TransIP shows after the key pair is created and keep it somewhere safe (it is shown only once)
+3. Decide how the key may be used, which sets the **global key** value in Cloud 66:
+   - To let Cloud 66 connect from any IP, allow the key to be used from non-whitelisted IP addresses and set **global key** to `yes` (the default).
+   - To keep the key restricted, set **global key** to `no` and whitelist the addresses Cloud 66 connects from (contact Cloud 66 support for these).
+4. Copy the **private key** TransIP shows after the key pair is created and save it to a file (it is shown only once).
 
-When adding TransIP to your Cloud 66 account, enter your TransIP **username** and paste the private key as the **API key** ([see above](#set-up-a-dns-provider)).
+When adding TransIP to your Cloud 66 account, enter your **username** and upload your private key file as the **API key** ([see above](#set-up-a-dns-provider)).

--- a/partials/_transip_dns.mdx
+++ b/partials/_transip_dns.mdx
@@ -1,0 +1,10 @@
+TransIP requires your account **username**, an **API key**, and a **global key** setting. The API key is the private key from a TransIP *key pair*, which you create in the control panel.
+
+1. Log into the [TransIP control panel](https://www.transip.eu/cp/) and go to **My account → API**
+2. Add a new **key pair** and give it a label (for example, `cloud66`)
+3. Choose how the key may be used:
+   - Allow it to be used from non-whitelisted IP addresses, and set **global key** to `yes` when you add it to Cloud 66, or
+   - Keep it restricted to whitelisted IPs, in which case you must whitelist the addresses Cloud 66 connects from (contact Cloud 66 support for these) and leave **global key** unset
+4. Copy the **private key** that TransIP shows after the key pair is created and keep it somewhere safe (it is shown only once)
+
+When adding TransIP to your Cloud 66 account, enter your TransIP **username** and paste the private key as the **API key** ([see above](#set-up-a-dns-provider)).

--- a/security/dns-providers.mdx
+++ b/security/dns-providers.mdx
@@ -2,6 +2,7 @@
 title: Adding DNS providers
 ---
 
+import AzureDnsPartial from '../partials/_azure_dns.mdx';
 import CloudflareDnsPartial from '../partials/_cloudflare_dns.mdx';
 import DigitaloceanDnsPartial from '../partials/_digitalocean_dns.mdx';
 import DnsimpleDnsPartial from '../partials/_dnsimple_dns.mdx';
@@ -16,6 +17,7 @@ import OvhDnsPartial from '../partials/_ovh_dns.mdx';
 import Rfc2136DnsPartial from '../partials/_rfc2136_dns.mdx';
 import Route53DnsPartial from '../partials/_route53_dns.mdx';
 import SakuracloudDnsPartial from '../partials/_sakuracloud_dns.mdx';
+import TransipDnsPartial from '../partials/_transip_dns.mdx';
 
 
 ## Overview 
@@ -27,6 +29,10 @@ If your provider is not listed, consider using [RFC 2136](https://www.rfc-editor
 ## Instructions per DNS provider
 
 Each DNS provider has specific credentials that need to be created and then [added to your Cloud 66 account](/:product/:version?/security/ssl#step-1-set-up-a-dns-provider). Find your provider below for more details.
+
+### Azure
+
+<PartialWrapper partial={AzureDnsPartial} />
 
 ### Cloudflare
 
@@ -83,3 +89,7 @@ Each DNS provider has specific credentials that need to be created and then [add
 ### SakuraCloud
 
 <PartialWrapper partial={SakuracloudDnsPartial} />
+
+### TransIP
+
+<PartialWrapper partial={TransipDnsPartial} />

--- a/security/dns-providers.mdx
+++ b/security/dns-providers.mdx
@@ -8,6 +8,7 @@ import DnsimpleDnsPartial from '../partials/_dnsimple_dns.mdx';
 import DnsmadeeasyDnsPartial from '../partials/_dnsmadeeasy_dns.mdx';
 import GehirnDnsPartial from '../partials/_gehirn_dns.mdx';
 import GoogleDnsPartial from '../partials/_google_dns.mdx';
+import HetznerDnsPartial from '../partials/_hetzner_dns.mdx';
 import LinodeDnsPartial from '../partials/_linode_dns.mdx';
 import LuadnsDnsPartial from '../partials/_luadns_dns.mdx';
 import Ns1DnsPartial from '../partials/_ns1_dns.mdx';
@@ -50,6 +51,10 @@ Each DNS provider has specific credentials that need to be created and then [add
 ### Google
 
 <PartialWrapper partial={GoogleDnsPartial} />
+
+### Hetzner
+
+<PartialWrapper partial={HetznerDnsPartial} />
 
 ### Linode
 


### PR DESCRIPTION
## What

Documents the three DNS providers that were registered in central's `DnsProviders::Factory` but had no page in help-content. The docs now cover **all 16 providers 1:1** with the factory. This is the docs counterpart to central's Hetzner/Azure/TransIP providers and commissioner's certbot plugins.

New partials (each follows the existing per-provider partial style):

- **`partials/_hetzner_dns.mdx`** — single **API token** from the **Hetzner Console** (`console.hetzner.cloud` → Security → API tokens → Read & Write). Calls out that it is *not* the legacy `dns.hetzner.com` DNS Console, since `certbot-dns-hetzner` v4 only supports the Hetzner Cloud API.
- **`partials/_azure_dns.mdx`** — a **service principal** (Microsoft Entra ID app registration) with the **DNS Zone Contributor** role, plus the five values central collects: subscription ID, tenant ID, client ID, client secret, resource group.
- **`partials/_transip_dns.mdx`** — a TransIP **key pair** for the three fields central collects (username, API key, global key). The API key is a **file upload** and **global key** defaults to `yes` (both verified against the central form). Presents both the IP-whitelist (`global key = no`) and non-whitelisted (`global key = yes`) options so the reader chooses the security tradeoff.

Wired into both provider enumerations: `security/dns-providers.mdx` (sections) and `partials/_dns_provider_tabs.mdx` (the picker used in the SSL setup flow), kept alphabetical (Azure first, TransIP last; Hetzner falls between Google and Linode).

## Verification

Credential models verified against source, not guessed:
- central `app/models/dns_providers/providers/{hetzner,azure,transip}.rb` (`expose_params`, `type_name`) and `app/views/dns_providers/_provider_fields.html.erb` (which fields are file uploads / required / defaulted).
- commissioner `plugins/plugin-{hetzner,azure,transip}.go` + `Dockerfile` (certbot plugin versions and credential keys).
- Provider-side steps verified against Hetzner docs / `ctrlaltcoop/certbot-dns-hetzner`, the `certbot-dns-azure` docs (DNS Zone Contributor role), and the TransIP control-panel docs.