### PR TITLE
Add DigitalOcean to Deploy v3 supported cloud providers

### DIFF
--- a/getting-started/deploy-v2-vs-v3.mdx
+++ b/getting-started/deploy-v2-vs-v3.mdx
@@ -53,7 +53,7 @@ Additional highlights of Deploy v3:
 * Enables **auxiliary services** like databases to run inside clusters.
 * Provides **shared and scalable persistent storage**.
 * Generates **native Kubernetes manifests**, which can be customized and extended, unlocking the full Kubernetes ecosystem.
-* Initial cloud support includes **Hetzner** and **Vultr**, with more providers on the roadmap.
+* Initial cloud support includes **DigitalOcean**, **Hetzner**, and **Vultr**, with more providers on the roadmap.
 
 ## Benefits of Deploy v3
 
@@ -92,7 +92,7 @@ Deploy v3 also introduces the concept of **node pools**, which allow different w
 | Node OS                   | Ubuntu                                                 | Flatcar (read‑only)                                              |
 | Node pools                | Not supported                                          | Supported (target workloads to GPU, high‑IO, etc.)               |
 | Cloud-native CSI/CNI      | Not supported                                          | Supported                                                        |
-| Supported cloud providers | AWS, DigitalOcean, Google Cloud, Azure, Hetzner, Vultr | Hetzner, Vultr (initial)                                         |
+| Supported cloud providers | AWS, DigitalOcean, Google Cloud, Azure, Hetzner, Vultr | DigitalOcean, Hetzner, Vultr (initial)                           |
 
 
 ## Summary

--- a/partials/_do.mdx
+++ b/partials/_do.mdx
@@ -4,6 +4,12 @@ You can use Cloud 66 to provision and deploy your code to servers (droplets) in 
 
 Private networking is enabled for all data centers that support it. This means that servers can communicate freely between each other on the same network without counting towards bandwidth costs.
 
+<PerProduct includes={['deploy']}>
+    <Callout type="info" title="Support for Deploy v3">
+        DigitalOcean is supported in Deploy v3. Please see the [Deploy v3 documentation](/deploy/getting-started/deploy-v2-vs-v3) for more information.
+    </Callout>
+</PerProduct>
+
 **Help with advanced Digital Ocean features:**
 * [Bring Your Own Images](/:product/:version?/deployment/bring-your-own-images) (BYOI) 
 * [Cloud 66 tag propagation](/:product/:version?/servers/tagging-components#propagation-of-tags-to-cloud-providers)

--- a/partials/_vultr.mdx
+++ b/partials/_vultr.mdx
@@ -13,6 +13,6 @@ You will use this key to add Vultr as a Deployment Target (see below).
 
 <PerProduct includes={['deploy']}>
     <Callout type="info" title="Support for Deploy v3">
-        Hetzner Cloud is supported in Deploy v3. Please see the [Deploy v3 documentation](/deploy/getting-started/deploy-v2-vs-v3) for more information.
+        Vultr is supported in Deploy v3. Please see the [Deploy v3 documentation](/deploy/getting-started/deploy-v2-vs-v3) for more information.
     </Callout>
 </PerProduct>


### PR DESCRIPTION
## What

Deploy v3 now supports **DigitalOcean** (alongside Hetzner and Vultr), but the docs still listed only Hetzner and Vultr. This brings the docs in line with the current supported-provider set.

## Changes

- **getting-started/deploy-v2-vs-v3.mdx** — add DigitalOcean to the "Initial cloud support" bullet and the "Supported cloud providers" comparison-table row (table padding preserved).
- **partials/_do.mdx** — add the "Support for Deploy v3" callout, matching the existing Hetzner and Vultr partials.
- **partials/_vultr.mdx** — fix a copy-paste error: the Vultr partial's v3 callout incorrectly read "Hetzner Cloud is supported in Deploy v3"; corrected to "Vultr".

## Source of truth

central `Cloud::CLOUDS` (`app/models/cloud.rb`) marks `digitalocean`, `vultr` and `hetzner` with `supports_csv3: true`, mirrored by `CSV3_SUPPORTED_CLOUDS = %w[digitalocean vultr hetzner]` in the CSv3 onboarding controller. AWS remains unsupported.

Prompted by support ticket #33670.