### PR TITLE
Fix Amplify build: scope cluster-operations to v3, repair broken links

### DIFF
--- a/build-and-config/cluster-operations.mdx
+++ b/build-and-config/cluster-operations.mdx
@@ -2,6 +2,7 @@
 title: CSv3 cluster operations
 description: "Add, resize, cordon, and drain nodes on a Cloud 66 CSv3 (K3s) cluster from the Dashboard, including the timeline error messages you may hit and how to fix them."
 products: ['deploy']
+includeVersions: ['3']
 ---
 
 ## Overview
@@ -169,5 +170,5 @@ If a drain times out you can also drop to `kubectl` directly with your downloade
 
 ## Related
 
-- [Database replication](/:product/:version?/databases/3/database-replication) — replication requirements that affect scale-down
+- [Database replication](/:product/:version?/databases/database-replication) — replication requirements that affect scale-down
 - [Kubernetes documentation — Safely drain a node](https://kubernetes.io/docs/tasks/administer-cluster/safely-drain-node/) — upstream reference for drain semantics

--- a/build-and-config/long-running-sidekiq-across-deploys.mdx
+++ b/build-and-config/long-running-sidekiq-across-deploys.mdx
@@ -8,7 +8,7 @@ products: ['rails', 'deploy']
 
 When you deploy, Cloud 66 restarts your background processes — including Sidekiq workers. If a Sidekiq job is mid-execution when its worker is restarted, the job is interrupted and (depending on its retry settings) may be retried, abandoned, or lost. For long-running jobs this is a real risk: a job that takes 90 seconds will rarely finish in the few seconds between a `TERM` signal and a forced `KILL`.
 
-The fix is to tell Cloud 66's process manager how to drain Sidekiq gracefully: first signal Sidekiq to stop fetching new jobs but keep working on the ones already in flight, then give it enough time to finish, and only then send `TERM` and `KILL`. This is configured via `procfile_metadata.stop_sequence` in your [manifest file](/:product/:version?/manifest/manifest).
+The fix is to tell Cloud 66's process manager how to drain Sidekiq gracefully: first signal Sidekiq to stop fetching new jobs but keep working on the ones already in flight, then give it enough time to finish, and only then send `TERM` and `KILL`. This is configured via `procfile_metadata.stop_sequence` in your [manifest file](/:product/:version?/manifest/what-is-a-manifest-file).
 
 ## Which signal does what
 


### PR DESCRIPTION
## Problem

The Amplify build of the docs site (help-cloud66-com, which consumes this repo as a submodule) fails at `yarn validate:mdx`:

> Version-specific file exists without a generic version. Found `src/docs/build-and-config/3/cluster-operations.mdx` but missing `src/docs/build-and-config/cluster-operations.mdx`.

The CSv3 cluster-operations page (added in #17) was placed at `build-and-config/3/cluster-operations.mdx` as a version-3 override, but the validator (`help-cloud66-com/scripts/validate-mdx.ts`) requires every `<dir>/<version>/<file>.mdx` to have a generic base `<dir>/<file>.mdx`. The page is K3s/CSv3-only, so there is no v1/v2 base.

## Fix

- **Move** `build-and-config/3/cluster-operations.mdx` → `build-and-config/cluster-operations.mdx` and scope it to v3 with `includeVersions: ['3']` (the idiomatic frontmatter scoping used elsewhere in the repo). This removes the version directory entirely, so the orphaned-file rule no longer applies, while keeping the page v3-only.

Two pre-existing broken internal links are also fixed — they were latent because the build died at `validate:mdx` and never reached `validate:links`:

- `cluster-operations`: `databases/3/database-replication` → `databases/database-replication` (the `:version?` placeholder already routes to the v3 variant)
- `long-running-sidekiq-across-deploys`: `manifest/manifest` → `manifest/what-is-a-manifest-file` (`manifest/manifest` is a section container with no leaf path)

## Test results

Ran the actual Amplify content gates locally (`help-cloud66-com`, submodule = this branch), from the repo root, in build order.

**Reproduced the failure first** (submodule at `origin/main`), matching the Amplify log exactly:

```
❌ Found 1 validation error(s) in 378 MDX files:
  1. src/docs/build-and-config/3/cluster-operations.mdx:
     Version-specific file exists without a generic version. ...
```

**After this branch — all gates pass:**

| Gate | Result |
|------|--------|
| `yarn validate:mdx` | ✅ All 378 MDX files passed validation! (+ `_order.yaml` valid) |
| `yarn validate:smart-links` | ✅ All smart link placeholders properly formatted |
| `yarn generate:known-paths` | ✅ generated |
| `yarn validate:links --skip-anchors` | ✅ exit 0 — All internal links are valid! |

(`lint` / `tsc` / `next build` are help-cloud66-com app-level steps, unaffected by content changes.)

## Note for deploy

Amplify pins the submodule commit, so the site rebuilds green only once `help-cloud66-com`'s `src/docs` submodule pointer advances to include this merge (auto-bumped, or a follow-up pointer commit in help-cloud66-com).