### PR TITLE
Fix mis-indented HAProxy load balancer manifest example

### DIFF
--- a/manifest/_load-balancer-haproxy.mdx
+++ b/manifest/_load-balancer-haproxy.mdx
@@ -36,12 +36,12 @@ Refer to the [HAProxy documentation](http://haproxy.1wt.eu/download/1.3/doc/conf
 ```yaml
 load_balancer:
   servers:
-  - server:
-    unique_name: bananana
-    size: 1gb
-    region: ams2
-    vendor: digitalocean
-    key_name: Default
+    - server:
+        unique_name: bananana
+        size: 1gb
+        region: ams2
+        vendor: digitalocean
+        key_name: Default
   configuration:
     httpchk: "HEAD / HTTP/1.1\r\nHost:haproxy"  #default value
     balance: roundrobin #default value


### PR DESCRIPTION
## What
Fixes the mis-indented YAML in the HAProxy load balancer manifest example (`manifest/_load-balancer-haproxy.mdx`).

## Why
The `server` block's keys (`unique_name`, `size`, `region`, `vendor`, `key_name`) sat at the same indentation as `server:` rather than nested under it. As YAML the list item parses to `{ server: nil, unique_name: ..., ... }`, so the provisioning code that reads `load_balancer/servers` and then `first[:server][:size]` etc. gets `nil` for the server and fails. Anyone copying the example verbatim would hit this.

## Change
Nest the server keys under `server:` (and indent the list item under `servers:`). Docs-only, single file, indentation-only.

Found via a Help Scout support question.