### PR TITLE
Document ARM support in Deploy v2/v3 clusters and registered servers

### DIFF
--- a/getting-started/deploy-v2-vs-v3.mdx
+++ b/getting-started/deploy-v2-vs-v3.mdx
@@ -7,7 +7,7 @@ products: ['deploy']
 Cloud 66 Deploy v3 is a major upgrade from Deploy v2, designed to offer more flexibility, reliability, and alignment with modern Kubernetes practices.
 
 
-Both versions share the same foundation: Kubernetes, BuildGrid for building container images, and a hosted image repository, but each has its own strengths.
+Both versions share the same foundation: Kubernetes, BuildGrid for building container images, a hosted image repository, and support for both AMD and ARM CPUs, but each has its own strengths.
 
 Deploy v3 introduces a new architecture that better meets today’s operational and cost requirements, while Deploy v2 continues to provide mature features that remain valuable for many use cases.
 
@@ -49,7 +49,7 @@ Additional highlights of Deploy v3:
 
 * Runs on **Flatcar Linux** as a read‑only, immutable OS for security and reduced maintenance.
 * Introduces **node pools**, allowing targeted workloads (e.g., GPUs for AI, high‑IO nodes for databases).
-* Supports **AMD and ARM CPUs**, as well as **GPUs**.
+* Supports **GPUs**.
 * Enables **auxiliary services** like databases to run inside clusters.
 * Provides **shared and scalable persistent storage**.
 * Generates **native Kubernetes manifests**, which can be customized and extended, unlocking the full Kubernetes ecosystem.
@@ -67,7 +67,6 @@ Additional highlights of Deploy v3:
 
 Deploy v3 also introduces several new capabilities not available in Deploy v2:
 
-* Support for both **AMD and ARM CPUs**
 * Support for **GPUs**
 * Ability to run **auxiliary services** such as databases inside containers and clusters
 * **Shared and scalable persistent storage** using cloud‑native disks or Longhorn
@@ -122,7 +121,7 @@ When deciding which version to use, consider the following:
 * **Choose Deploy v3 if:**
 
 * You want a modern, Kubernetes‑native architecture with a focus on flexibility and growth.
-* You plan to take advantage of features such as node pools, support for ARM/AMD CPUs, GPUs, and native manifest generation.
+* You plan to take advantage of features such as node pools, GPUs, and native manifest generation.
 * You are comfortable adopting an early access product and contributing feedback to shape its future.
 
 In practice, many teams may use both: continuing established workloads on Deploy v2 while exploring Deploy v3 for new projects or environments that benefit from its emerging capabilities.

--- a/getting-started/getting-started-with-clusters.mdx
+++ b/getting-started/getting-started-with-clusters.mdx
@@ -33,6 +33,10 @@ You can also use your own server - although you will need to [register it](/:pro
 
 Depending on which cloud or registered server you selected above, we can now choose options for our new cluster, such as region and capacity. In this example we'll choose *3* servers with 2GB of RAM each in the Amsterdam 3 Region.
 
+<Callout type="info" title="ARM support">
+Clusters support both AMD/Intel (x86-64) and ARM64 servers. To use ARM, choose a cloud instance type that's ARM-based when picking your cluster's capacity, or, for your own servers, run the [registration script](/:product/:version?/servers/registered-servers#register-a-server) on an ARM machine.
+</Callout>
+
 <Callout type="info" title="First server is always the master node">
  The first server in your cluster will always be your Kubernetes master node. You can decide later if you would like this server to share application workloads or only run Kubernetes management tasks. 
 </Callout>

--- a/servers/registered-servers.mdx
+++ b/servers/registered-servers.mdx
@@ -68,7 +68,7 @@ To add a server behind your gateway:
 - **Connection**: For security reasons, Cloud 66 only connects to your server using your secure keys on **port 22**.
 - **Sudo**: As Cloud 66 connects to your server and provisions applications from scratch, administrator permissions are sometimes necessary. Therefore our script creates a new user to use for deployment that is a member of the sudoers group and that does not require a password to invoke sudo.
 - **Bash**: We currently only support Bourne-again shell (Bash). The error `sh: n: source: not found` during deployment may arise if you are not using the Bash shell.
-- **CPU Architecture**: We only support deploying to 64-bit machines.
+- **CPU Architecture**: We support 64-bit machines on both AMD/Intel (x86-64) and ARM64. To register an ARM server, run the [registration script](#register-a-server) on the ARM machine the same way you would on any other server.
 - **Firewalls & security:** Cloud 66 needs the following (TCP) ports open to allow us to deploy and manage your application:
     - Port `22` set to allow access from our [authorized IP addresses](/:product/:version?/security/using-c66-via-firewall#cloud-66-s-authorized-ip-addresses)
     - Port `6443` set to allow access from our [authorized IP addresses](/:product/:version?/security/using-c66-via-firewall#cloud-66-s-authorized-ip-addresses)
@@ -80,7 +80,7 @@ To add a server behind your gateway:
 - **Connection**: For security reasons, Cloud 66 only connects to your server using your secure keys on **port 22**.
 - **Sudo**: As Cloud 66 connects to your server and provisions applications from scratch, administrator permissions are sometimes necessary. Therefore our script creates a new user to use for deployment that is a member of the sudoers group and that does not require a password to invoke sudo.
 - **Bash**: We currently only support Bourne-again shell (Bash). The error `sh: n: source: not found` during deployment may arise if you are not using the Bash shell.
-- **CPU Architecture**: We only support deploying to 64-bit machines.
+- **CPU Architecture**: We support 64-bit machines on both AMD/Intel (x86-64) and ARM64. To register an ARM server, run the [registration script](#register-a-server) on the ARM machine the same way you would on any other server.
 - **Firewalls & security:** Cloud 66 needs the following (TCP) ports open to allow us to deploy and manage your application:
     - Port `22` set to allow access from our [authorized IP addresses](/:product/:version?/security/using-c66-via-firewall#cloud-66-s-authorized-ip-addresses)
     - Port `3022` set to allow access from `159.89.253.143` (this IP is static)


### PR DESCRIPTION
## Summary
- Deploy v2 (Clusters) and Rails applications now support ARM CPUs, not just Deploy v3, so `deploy-v2-vs-v3.mdx` no longer lists ARM/AMD support as a v3-only differentiator — it's now called out as a shared capability.
- `getting-started-with-clusters.mdx` gets a new callout explaining how to use ARM: pick an ARM-based cloud instance, or run the registration script on an ARM machine for your own servers.
- `registered-servers.mdx`'s "CPU Architecture" requirement (both the `deploy` and `rails` product blocks) now explicitly calls out ARM64 support alongside x86-64.

## Test plan
- [ ] Spot-check rendered pages for the `deploy` and `rails` product/version combinations to confirm the `PerProduct` blocks and callouts render correctly