### PR TITLE
Update operating system docs for Ubuntu 26.04 and document Deploy v3 path routing

### DIFF
--- a/build-and-config/managing-and-upgrading-ruby-versions.mdx
+++ b/build-and-config/managing-and-upgrading-ruby-versions.mdx
@@ -40,15 +40,7 @@ Older versions of Ruby depend on system libraries and compiler toolchains that a
 
 **Ruby versions below 2.5.0 are no longer supported.** These depend on package bindings only available on Ubuntu 18.04 and older, which is long out of LTS and no longer offered by most cloud providers. Attempting to deploy one will fail with an error asking you to upgrade Ruby to 2.5.0 or above. Please [log a support query](https://app.cloud66.com/support_tickets/new) if you need assistance with this.
 
-**Ruby versions below 3.2.0 are not available on Ubuntu 26.04.** They remain available on Ubuntu 22.04 and 24.04. If your application needs an older version of Ruby, either upgrade Ruby to 3.2.0 or above, or pin the operating system in your Manifest file:
-
-```yaml
-rails:
-  configuration:
-    operating_system: ubuntu2404
-```
-
-Ruby 3.2.0 and above is available on every version of Ubuntu we currently support. Since pinning an operating system means staying on a release that will eventually reach end-of-life, upgrading Ruby is usually the better long-term option.
+Ruby 2.5.0 and above is available on every version of Ubuntu we currently support, so if you are pinned to an old operating system it is almost always better to upgrade Ruby than to stay on a release that is approaching (or past) end-of-life.
 
 The version of Ubuntu used by your application is set using your application's [Manifest file](/:product/:version?/manifest/_rails-rack).
 

--- a/build-and-config/managing-and-upgrading-ruby-versions.mdx
+++ b/build-and-config/managing-and-upgrading-ruby-versions.mdx
@@ -36,11 +36,19 @@ If your `manifest.yml` specifies a different version to your Gemfile, this will 
 
 ## Ruby and Ubuntu versions
 
-Older versions of Ruby depend on system libraries that are no longer present in current versions of Ubuntu, so the two are linked.
+Older versions of Ruby depend on system libraries and compiler toolchains that are no longer present in current versions of Ubuntu, so the two are linked.
 
 **Ruby versions below 2.5.0 are no longer supported.** These depend on package bindings only available on Ubuntu 18.04 and older, which is long out of LTS and no longer offered by most cloud providers. Attempting to deploy one will fail with an error asking you to upgrade Ruby to 2.5.0 or above. Please [log a support query](https://app.cloud66.com/support_tickets/new) if you need assistance with this.
 
-Ruby 2.5.0 and above runs on every version of Ubuntu we currently support, so if you are pinned to an old operating system it is almost always better to upgrade Ruby than to stay on a release that is approaching (or past) end-of-life.
+**Ruby versions below 3.2.0 are not available on Ubuntu 26.04.** They remain available on Ubuntu 22.04 and 24.04. If your application needs an older version of Ruby, either upgrade Ruby to 3.2.0 or above, or pin the operating system in your Manifest file:
+
+```yaml
+rails:
+  configuration:
+    operating_system: ubuntu2404
+```
+
+Ruby 3.2.0 and above is available on every version of Ubuntu we currently support. Since pinning an operating system means staying on a release that will eventually reach end-of-life, upgrading Ruby is usually the better long-term option.
 
 The version of Ubuntu used by your application is set using your application's [Manifest file](/:product/:version?/manifest/_rails-rack).
 

--- a/build-and-config/managing-and-upgrading-ruby-versions.mdx
+++ b/build-and-config/managing-and-upgrading-ruby-versions.mdx
@@ -36,10 +36,11 @@ If your `manifest.yml` specifies a different version to your Gemfile, this will 
 
 ## Ruby and Ubuntu versions
 
-Older versions of Ruby require that your application servers are built using older versions of Ubuntu. 
+Older versions of Ruby depend on system libraries that are no longer present in current versions of Ubuntu, so the two are linked.
 
-- If your Ruby version is < 2.5.0 then the maximum allowed version of Ubuntu is 18.04
-- If your Ruby version < 3.1.0 (but higher than 2.5.0) then the maximum allowed version of Ubuntu is 20.04
+**Ruby versions below 2.5.0 are no longer supported.** These depend on package bindings only available on Ubuntu 18.04 and older, which is long out of LTS and no longer offered by most cloud providers. Attempting to deploy one will fail with an error asking you to upgrade Ruby to 2.5.0 or above. Please [log a support query](https://app.cloud66.com/support_tickets/new) if you need assistance with this.
+
+Ruby 2.5.0 and above runs on every version of Ubuntu we currently support, so if you are pinned to an old operating system it is almost always better to upgrade Ruby than to stay on a release that is approaching (or past) end-of-life.
 
 The version of Ubuntu used by your application is set using your application's [Manifest file](/:product/:version?/manifest/_rails-rack).
 

--- a/manifest/_server-definitions.mdx
+++ b/manifest/_server-definitions.mdx
@@ -76,7 +76,7 @@ For example:
 rails:
   configuration:
     ...
-    operating_system: ubuntu2404
+    operating_system: ubuntu2604
 ```
 
 ## Detailed examples of Manifest files

--- a/networking/service-networking.mdx
+++ b/networking/service-networking.mdx
@@ -171,6 +171,53 @@ Some example of default ports used by popular programming frameworks or applicat
 |InfluxDB|8083, 8086, 8090, 8099|
 |Python (Django)|8000|
 
+<PerProduct includes={["deploy"]} includeVersions={['3']}>
+## Traffic matching
+
+Traffic reaches your services through **traffic sources** - a combination of a domain name and an optional URL path. You manage these from the *Traffic* page of your cluster rather than in a configuration file.
+
+A traffic source with no path sends every request for that domain to a single service. Adding a path allows several services in the same application to share one domain.
+
+### Routing by URL path
+
+For example, you might serve the front end and the API of the same product from separate services:
+
+| Address | Path | Service |
+| --- | --- | --- |
+| `example.com` | | `web` |
+| `example.com` | `/api` | `api` |
+
+Requests to `example.com/api`, and anything beneath it such as `example.com/api/v2/users`, are routed to the `api` service. Every other request for `example.com` goes to `web`.
+
+Path matching is *segment-exact*, so a path of `/api` matches `/api` and `/api/v2` but does not match `/api-internal` or `/apiary`.
+
+<Callout type="info" title="The matched path is removed">
+The path you match on is stripped from the request before it reaches your service. A service behind `/api` receives a request for `/v2/users` rather than `/api/v2/users`, so it doesn't need to know which path it has been mounted at. Redirects and maintenance mode still see the original URL.
+</Callout>
+
+### Adding a traffic source
+
+1. Log into your [Dashboard](https://app.cloud66.com/) and open your cluster
+2. Click *Network & Traffic* in the left-hand nav and open the *Traffic* tab
+3. Click *New Traffic Source*
+4. Enter the **Domain name**, without `http://`, `https://` or a trailing slash
+5. Optionally enter a **Path** such as `/app` or `/api/v2`. Leave this blank to route all requests for the domain.
+6. Choose the **Destination service**
+7. Choose how the [SSL certificate](/:product/:version?/security/ssl) for this domain should be issued or supplied
+8. Click *Save*
+
+You will also need to point the domain's DNS record at your cluster's load balancer so that traffic can reach it.
+
+### Rules and limitations
+
+- **Paths require HTTP or HTTPS.** A path can only be set on a service that exposes an external HTTP or HTTPS port. TCP and UDP traffic is matched on the domain alone and cannot be routed by path.
+- **A domain belongs to a single application.** All paths on a given domain must point to services within the same application.
+- **Each domain and path combination must be unique** across the cluster.
+- **Paths must be valid URL paths** beginning with `/`. They cannot contain spaces, query strings or fragments. Trailing slashes are ignored, so `/app/` and `/app` are treated as the same path.
+- Services created before path routing was introduced are updated automatically the first time you add a path. If a service uses customized templates that predate the feature, update them to the latest version first.
+</PerProduct>
+
+<PerProduct includes={["rails", "deploy"]} excludeVersions={['3']}>
 ## Traffic matching
 
 The `traffic_matches` option allows you to route incoming traffic to different services based on the incoming domain name. You can specify an array of domains (as strings) to match to your service.
@@ -223,6 +270,7 @@ The `traffic_matches` option can also be used to ensure that any and all traffic
 ```
 
 Be cautious with this approach as it is effectively a global setting and may disrupt your other services if there are any conflicts.
+</PerProduct>
 
 ## DNS Behaviour
 

--- a/servers/applying-upgrades.mdx
+++ b/servers/applying-upgrades.mdx
@@ -138,4 +138,4 @@ If your application depends on older or legacy packages, these packages (or the 
 
 ### "...has no installation candidate" errors
 
-This typically only occurs if you're using your own ("registered") servers and running an unsupported operating system and/or distribution. We only support the two most recent major releases of Ubuntu. You can check what we currently support here. The best plan here is to reinstall a supported version of Ubuntu.
+This typically only occurs if you're using your own ("registered") servers and running an unsupported operating system and/or distribution. You can [check which versions of Ubuntu we currently support](/:product/:version?/specs-and-policies/technical-specifications#operating-system). The best plan here is to reinstall a supported version of Ubuntu.

--- a/servers/out-of-ubuntu-lts.mdx
+++ b/servers/out-of-ubuntu-lts.mdx
@@ -9,7 +9,16 @@ If one or more of the servers in your application are running older versions of 
 
 ## Understanding LTS and EOL
 
-Free versions of Ubuntu are supported by Canonical for 5 years after their initial release - hence the label “long term support”. This means that a version released in 2018 (i.e. 18.04) is no longer eligible for support as of April 2023 and effectively becomes EOL.
+Free versions of Ubuntu are supported by Canonical for 5 years after their initial release - hence the label “long term support”. A version released in April 2020 (i.e. 20.04) therefore stopped being eligible for free support in April 2025 and effectively became EOL.
+
+The table below shows when each recent LTS release reaches the end of its free support window:
+
+| Ubuntu LTS release | Released | Free support ends |
+| --- | --- | --- |
+| 20.04 | April 2020 | April 2025 (EOL) |
+| 22.04 | April 2022 | April 2027 |
+| 24.04 | April 2024 | April 2029 |
+| 26.04 | April 2026 | April 2031 |
 
 At this point [Canonical](https://canonical.com/) stops actively releasing updates and patches to that version of Ubuntu. Some package maintainers will patch older versions of their software, but many will drop support as the respective versions of Ubuntu reach EOL.
 

--- a/servers/querying-server-metadata.mdx
+++ b/servers/querying-server-metadata.mdx
@@ -83,7 +83,7 @@ curl localhost:17540/metadata/server/os | jq
 `{
   "response": {
     "distro": "ubuntu",
-    "version": "18.04"
+    "version": "26.04"
   }
 }
 ```

--- a/servers/server-monitoring.mdx
+++ b/servers/server-monitoring.mdx
@@ -39,7 +39,7 @@ Cloud 66 automatically installs and configures the monitoring service (based on 
 
 Most cloud providers now offer built-in server resource monitoring via their online dashboard, which can be a useful addition to your monitoring. If you need more specific detail (such as code-level monitoring) or or more granular reporting, we recommend implementing one of the many excellent cloud reporting solutions (see below).
 
-Cloud 66 supports any third-party resource monitoring solution that is compatible with servers running on the two most recent LTS versions of Ubuntu. We have listed some commonly used solutions below, but this list is not exhaustive.
+Cloud 66 supports any third-party resource monitoring solution that is compatible with servers running [the versions of Ubuntu we currently support](/:product/:version?/specs-and-policies/technical-specifications#operating-system). We have listed some commonly used solutions below, but this list is not exhaustive.
 
 ## Adding external monitoring services to your app
 

--- a/specs-and-policies/technical-specifications.mdx
+++ b/specs-and-policies/technical-specifications.mdx
@@ -8,6 +8,18 @@ title: Cloud 66 Technical specifications
 Your servers are deployed with <OperatingSystemsWrapper />.
 </PerProduct>
 
+<PerProduct includes={["rails", "deploy"]} excludeVersions={['3']}>
+### How we choose your server's operating system
+
+Unless you pin a version in your [Manifest file](/:product/:version?/manifest/_server-definitions#specifying-an-operating-system-version), we choose the operating system for each new server as follows:
+
+1. **New applications** are provisioned with the latest LTS release we support.
+2. **Existing applications** keep the release already running on their servers of that type. We will not introduce a newer release into a running application on your behalf, so that servers which are meant to be identical stay identical.
+3. **Some components stay on an older release** where the newer one has no upstream packages yet. MongoDB is the current example — MongoDB servers are provisioned with Ubuntu 24.04.
+
+This means that scaling up a server on an established application will match its existing servers rather than jumping to the newest release. To move an existing application forward, either set `operating_system` in your Manifest file or follow our guide to [upgrading servers running older versions of Ubuntu](/:product/:version?/servers/out-of-ubuntu-lts).
+</PerProduct>
+
 ## Supported cloud providers
 
 Cloud 66 currently supports the following cloud providers:

--- a/specs-and-policies/technical-specifications.mdx
+++ b/specs-and-policies/technical-specifications.mdx
@@ -5,7 +5,7 @@ title: Cloud 66 Technical specifications
 <PerProduct includes={["rails", "deploy"]}>
 ## Operating system
 
-Your servers are deployed with <OperatingSystemsWrapper />.
+Your servers are deployed with <OperatingSystemsWrapper showAll={true} />.
 </PerProduct>
 
 <PerProduct includes={["rails", "deploy"]} excludeVersions={['3']}>


### PR DESCRIPTION
## Summary

Two documentation updates: one following the Ubuntu 26.04 release, one covering path-based routing in Deploy v3.

## Ubuntu 26.04

Ubuntu 26.04 is now the default for newly provisioned servers, which left a number of operating system references out of date or incorrect.

**Corrections**

- `servers/applying-upgrades.mdx` and `servers/server-monitoring.mdx` both claimed we support "the two most recent" releases of Ubuntu. We support more than two, and hardcoding a count goes stale every release, so both now link to the technical specifications page instead. This also supplies a link that the applying-upgrades sentence was missing entirely — "You can check what we currently support here" pointed nowhere.
- `build-and-config/managing-and-upgrading-ruby-versions.mdx` — the Ruby and Ubuntu versions section listed two rules that no longer apply. Ruby below 2.5.0 is no longer supported at all rather than being capped at Ubuntu 18.04, and the claimed Ubuntu 20.04 cap for Ruby below 3.1.0 no longer applies.
- `manifest/_server-definitions.mdx` — `operating_system` example updated to `ubuntu2604`.
- `servers/querying-server-metadata.mdx` — sample response updated from 18.04 to 26.04.

**New content**

- `specs-and-policies/technical-specifications.mdx` gains "How we choose your server's operating system". This covers why a newly scaled server on an established application matches its existing servers rather than jumping to the latest release, and why MongoDB servers stay on Ubuntu 24.04. Scoped to exclude Deploy v3, whose nodes run Flatcar.
- `servers/out-of-ubuntu-lts.mdx` gains an LTS end-of-life table covering 20.04 through 26.04, replacing a worked example based on 18.04 and 2023.

A companion change to the documentation site handles rendering of the new version.

## Deploy v3 path-based routing

Traffic sources in Deploy v3 now take an optional URL path alongside the domain, so several services in one application can share a domain.

`networking/service-networking.mdx` gains a Deploy v3 traffic matching section covering how path routing works, how to add a traffic source from the cluster Traffic page, and the rules that apply:

- matching is segment-exact, so `/api` matches `/api` and `/api/v2` but not `/api-internal`
- the matched path is stripped before the request reaches the service
- paths require a service exposing an external HTTP or HTTPS port; TCP and UDP are matched on domain alone
- a domain is owned by a single application, and each domain and path pair must be unique across the cluster

## Note for reviewers

The existing `traffic_matches` documentation on that page describes the `service.yml` array, which Deploy v3 does not use — but the page carried no version scoping, so it rendered on v3 as well. It is now scoped to exclude v3 so the two sections no longer contradict each other for v3 readers.

The rest of that page (port mapping, `dns_behaviour`, `load_balancing`) is still unscoped and still renders on v3. Left alone here, but worth a follow-up.

## Validation

`validate:mdx` (378 files), `validate:smart-links` and `validate:links --skip-anchors` all pass. New anchors were checked by hand, since the build does not validate them.
